### PR TITLE
add callback QueryStats with callback period

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,6 +8,14 @@ In order to accept your pull request, we need you to [submit a CLA](https://gith
 
 By contributing to Trino, you agree that your contributions will be licensed under the [Apache License Version 2.0 (APLv2)](LICENSE).
 
+# Go Test
+
+Please Run [go test](https://pkg.go.dev/testing) before creating Pull Request
+
+```bash
+go test -v -race -timeout 1m ./...
+```
+
 # Releases
 
 To create a new release, a maintainer with repository write permissions needs to create and push a new git tag.


### PR DESCRIPTION
### oss

- #12 

### test

test with 1 second callback period
- presto_test code is set as 0.1 * 1000 or 0.1 seconds for build purpose

Because callback period is set only at `running state` and test query is `SELECT 2`, `RUNNING -> FINISHED` state changes almost immediately so sometimes it passes `RUNNING state` before it fetches the state.
```
=== RUN   TestQueryWithCallbackAsParam
QUEUED, 0 
QUEUED, 0 
QUEUED, 0 
RUNNING, 0 
FINISHED, 100 
--- PASS: TestQueryWithCallbackAsParam (1.09s)
PASS


=== RUN   TestQueryWithCallbackAsParam
QUEUED, 0 
QUEUED, 0 
QUEUED, 0 
FINISHED, 0 
FINISHED, 0 
FINISHED, 100 
--- PASS: TestQueryWithCallbackAsParam (0.12s)
PASS
```

The reason why only `running state` has callback period (am sure you guys know much more about the whole API process) is because presto does not start the job until query is submitted. Here below is screenshot when there was 1 second callback period (query finished in 50ms while test RUN took 1 seconds), which means that this callback period does not delay presto processing time.

![스크린샷 2020-11-06 오후 3 11 56](https://user-images.githubusercontent.com/25147023/98501164-c83d6080-2291-11eb-80fd-8756c179b448.png)


______

#### edit of 2020-11-11

- changed callback period to argument passed instead of forcing user to define function for callback interface
- https://github.com/prestosql/presto-go-client/pull/14/commits/9d1a64d048a6d433138c7a69139d688bf7d68a45