### PR TITLE
Added `Arguments` parameter to `typeSignature`

### DIFF
--- a/presto/presto.go
+++ b/presto/presto.go
@@ -725,9 +725,15 @@ type queryColumn struct {
 type queryData []interface{}
 
 type typeSignature struct {
-	RawType          string        `json:"rawType"`
-	TypeArguments    []interface{} `json:"typeArguments"`
-	LiteralArguments []interface{} `json:"literalArguments"`
+	RawType          string                   `json:"rawType"`
+	Arguments        []typeSignatureParameter `json:"arguments"`
+	TypeArguments    []interface{}            `json:"typeArguments"`
+	LiteralArguments []interface{}            `json:"literalArguments"`
+}
+
+type typeSignatureParameter struct {
+	Kind  string      `json:"kind"`
+	Value interface{} `json:"value"`
 }
 
 type infoResponse struct {

--- a/presto/presto.go
+++ b/presto/presto.go
@@ -736,11 +736,6 @@ type typeSignatureParameter struct {
 	Value interface{} `json:"value"`
 }
 
-type infoResponse struct {
-	QueryID string `json:"queryId"`
-	State   string `json:"state"`
-}
-
 func handleResponseError(status int, respErr stmtError) error {
 	switch respErr.ErrorName {
 	case "":


### PR DESCRIPTION
I was implementing some kind of reverse proxy for Presto but `presto-cli` was not working with my reverse proxy. During the debugging, I have noticed that the arguments parameter is missing in the type signature struct.

P.S. I have also removed `infoResponse` since it is a private struct and unused.