### PR TITLE
implement ExecContext

### DIFF
--- a/trino/integration_test.go
+++ b/trino/integration_test.go
@@ -422,3 +422,37 @@ func TestIntegrationQueryParametersSelect(t *testing.T) {
 		})
 	}
 }
+
+func TestIntegrationExec(t *testing.T) {
+	db := integrationOpen(t)
+	defer db.Close()
+
+	_, err := db.Query(`SELECT count(*) FROM nation`)
+	expected := "Schema must be specified when session schema is not set"
+	if err == nil || !strings.Contains(err.Error(), expected) {
+		t.Fatalf("Expected to fail to execute query with error: %v, got: %v", expected, err)
+	}
+
+	result, err := db.Exec("USE tpch.sf100")
+	if err != nil {
+		t.Fatal("Failed executing query:", err.Error())
+	}
+	if result == nil {
+		t.Fatal("Expected exec result to be not nil")
+	}
+
+	a, err := result.RowsAffected()
+	if err != nil {
+		t.Fatal("Expected RowsAffected not to return any error, got:", err)
+	}
+	if a != 0 {
+		t.Fatal("Expected RowsAffected to be zero, got:", a)
+	}
+	rows, err := db.Query(`SELECT count(*) FROM nation`)
+	if err != nil {
+		t.Fatal("Failed executing query:", err.Error())
+	}
+	if rows == nil || !rows.Next() {
+		t.Fatal("Failed fetching results")
+	}
+}

--- a/trino/trino_test.go
+++ b/trino/trino_test.go
@@ -325,8 +325,13 @@ func TestUnsupportedTransaction(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer db.Close()
-	if _, err := db.Begin(); err == nil {
+	_, err = db.Begin()
+	if err == nil {
 		t.Fatal("unsupported transaction succeeded with no error")
+	}
+	expected := "operation not supported"
+	if !strings.Contains(err.Error(), expected) {
+		t.Fatalf("expected begin to fail with %s but got %v", expected, err)
 	}
 }
 

--- a/trino/trino_test.go
+++ b/trino/trino_test.go
@@ -302,17 +302,6 @@ func TestWithoutSSLCertPath(t *testing.T) {
 	}
 }
 
-func TestUnsupportedExec(t *testing.T) {
-	db, err := sql.Open("trino", "http://localhost:9")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer db.Close()
-	if _, err := db.Exec("CREATE TABLE foobar (V VARCHAR)"); err == nil {
-		t.Fatal("unsupported exec succeeded with no error")
-	}
-}
-
 func TestUnsupportedTransaction(t *testing.T) {
 	db, err := sql.Open("trino", "http://localhost:9")
 	if err != nil {

--- a/trino/trino_test.go
+++ b/trino/trino_test.go
@@ -275,6 +275,23 @@ func TestQueryFailure(t *testing.T) {
 	}
 }
 
+func TestUnsupportedHeader(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set(trinoSetRoleHeader, "foo")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+	db, err := sql.Open("trino", ts.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	_, err = db.Query("SELECT 1")
+	if err != ErrUnsupportedHeader {
+		t.Fatal("unexpected error:", err)
+	}
+}
+
 func TestSSLCertPath(t *testing.T) {
 	db, err := sql.Open("trino", "https://localhost:9?SSLCertPath=/tmp/invalid_test.cert")
 	if err != nil {


### PR DESCRIPTION
This PR implements `driver.ExecContext()` to be able to run queries like `USE <catalog>.<schema>` and possibly other DDL/DML queries. While this is rarely used in application code, I noticed this when trying to use the [usql](https://github.com/xo/usql) CLI client.

I also included few minor changes to satisfy `golangci-lint` linter, like adding comments and removing dead code.

When working on this I was reading https://github.com/prestosql/presto/blob/master/presto-jdbc/src/main/java/io/prestosql/jdbc/PrestoStatement.java as a reference.