### PR TITLE
Delete cancelled query

### DIFF
--- a/integration_tests/run.sh
+++ b/integration_tests/run.sh
@@ -5,36 +5,34 @@ LOCAL_PORT=8080
 # TODO update to trino after the release
 IMAGE_NAME=prestosql/presto
 
-cd "$( dirname "${BASH_SOURCE[0]}" )"
+cd "$(dirname "${BASH_SOURCE[0]}")" || exit 1
 
 function test_cleanup() {
-   docker rm -f $CONTAINER
+    docker rm -f "$CONTAINER"
 }
 
 trap test_cleanup EXIT
 
 function test_query() {
-	docker exec -t $CONTAINER bin/presto --server localhost:${LOCAL_PORT} --execute "$*"
+    docker exec -t "$CONTAINER" bin/presto --server localhost:${LOCAL_PORT} --execute "$*"
 }
 
 CONTAINER=$(docker run -v "$PWD/etc:/etc/presto" -p ${LOCAL_PORT}:${LOCAL_PORT} --rm -d $IMAGE_NAME)
 
 attempts=10
-while [ $attempts -gt 0 ]
-do
-	attempts=`expr $attempts - 1`
-	ready=`test_query "SHOW SESSION" | grep task_writer_count`
-	[ ! -z "$ready" ] && break
-	echo "waiting for trino..."
-	sleep 2
+while [ $attempts -gt 0 ]; do
+    attempts=$((attempts - 1))
+    ready=$(test_query "SHOW SESSION" | grep task_writer_count)
+    [ -n "$ready" ] && break
+    echo "waiting for trino..."
+    sleep 2
 done
 
-if [ $attempts -eq 0 ]
-then
-	echo "timed out waiting for trino"
-	exit 1
+if [ $attempts -eq 0 ]; then
+    echo "timed out waiting for trino"
+    exit 1
 fi
 
 PKG=../trino
 DSN=http://test@localhost:${LOCAL_PORT}
-go test -v -cover -coverprofile=coverage.out $PKG -trino_server_dsn=$DSN $*
+go test -v -race -timeout 10s -cover -coverprofile=coverage.out $PKG -trino_server_dsn=$DSN "$@"

--- a/trino/trino.go
+++ b/trino/trino.go
@@ -910,7 +910,7 @@ func newTypeConverter(typeName string) *typeConverter {
 // parses presto types, e.g. array(varchar(10)) to "array", "varchar"
 // TODO: Use queryColumn.TypeSignature instead.
 func parseType(name string) []string {
-	parts := strings.Split(name, "(")
+	parts := strings.Split(strings.ToLower(name), "(")
 	if len(parts) == 1 {
 		return parts
 	}


### PR DESCRIPTION
When using `QueryContext()` and canceling the context the driver should send a DELETE request to the server to stop the query from being executed and wasting resources.

I also added a 5s timeout to `go test` in `run.sh` and my editor ran `shfmt` on it, I hope it's not a problem. That fixed a few `shellcheck` issues as well (quoting, subshells etc).

I also made type comparison case insensitive, since the server might be using upper case for some types, like `INTERVAL`.