### PR TITLE
Finish rename to Trino

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,16 +75,16 @@ Please refer to the [Coordinator Kerberos Authentication](https://trino.io/docs/
 
 It's possible to pass user information to Trino, different from the principal used to authenticate to the coordinator. See the [System Access Control](https://trino.io/docs/current/develop/system-access-control.html) documentation for details.
 
-In order to pass user information in queries to Trino, you have to add a [NamedArg](https://godoc.org/database/sql#NamedArg) to the query parameters where the key is X-Presto-User. 
+In order to pass user information in queries to Trino, you have to add a [NamedArg](https://godoc.org/database/sql#NamedArg) to the query parameters where the key is X-Trino-User.
 This parameter is used by the driver to inform Trino about the user executing the query regardless of the authentication method for the actual connection, and its value is NOT passed to the query.
 
 Example:
 
 ```go
-db.Query("SELECT * FROM foobar WHERE id=?", 1, sql.Named("X-Presto-User", string("Alice")))
+db.Query("SELECT * FROM foobar WHERE id=?", 1, sql.Named("X-Trino-User", string("Alice")))
 ```
 
-The position of the X-Presto-User NamedArg is irrelevant and does not affect the query in any way.
+The position of the X-Trino-User NamedArg is irrelevant and does not affect the query in any way.
 
 ### DSN (Data Source Name)
 

--- a/integration_tests/etc/node.properties
+++ b/integration_tests/etc/node.properties
@@ -1,4 +1,4 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 node.environment=test
 node.id=test
-node.data-dir=/data/presto
+node.data-dir=/data/trino

--- a/integration_tests/run.sh
+++ b/integration_tests/run.sh
@@ -2,8 +2,7 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
 LOCAL_PORT=8080
-# TODO update to trino after the release
-IMAGE_NAME=prestosql/presto
+IMAGE_NAME=trinodb/trino
 
 cd "$(dirname "${BASH_SOURCE[0]}")" || exit 1
 
@@ -14,22 +13,22 @@ function test_cleanup() {
 trap test_cleanup EXIT
 
 function test_query() {
-    docker exec -t "$CONTAINER" bin/presto --server localhost:${LOCAL_PORT} --execute "$*"
+    docker exec -t "$CONTAINER" bin/trino --server localhost:${LOCAL_PORT} --execute "$*"
 }
 
-CONTAINER=$(docker run -v "$PWD/etc:/etc/presto" -p ${LOCAL_PORT}:${LOCAL_PORT} --rm -d $IMAGE_NAME)
+CONTAINER=$(docker run -v "$PWD/etc:/etc/trino" -p ${LOCAL_PORT}:${LOCAL_PORT} --rm -d $IMAGE_NAME)
 
 attempts=10
 while [ $attempts -gt 0 ]; do
     attempts=$((attempts - 1))
     ready=$(test_query "SHOW SESSION" | grep task_writer_count)
     [ -n "$ready" ] && break
-    echo "waiting for trino..."
+    echo "waiting for Trino..."
     sleep 2
 done
 
 if [ $attempts -eq 0 ]; then
-    echo "timed out waiting for trino"
+    echo "timed out waiting for Trino"
     exit 1
 fi
 

--- a/integration_tests/run.sh
+++ b/integration_tests/run.sh
@@ -34,4 +34,4 @@ fi
 
 PKG=../trino
 DSN=http://test@localhost:${LOCAL_PORT}
-go test -v -race -timeout 10s -cover -coverprofile=coverage.out $PKG -trino_server_dsn=$DSN "$@"
+go test -v -race -timeout 30s -cover -coverprofile=coverage.out $PKG -trino_server_dsn=$DSN "$@"

--- a/trino/integration_test.go
+++ b/trino/integration_test.go
@@ -477,7 +477,7 @@ func TestIntegrationUnsupportedHeader(t *testing.T) {
 		},
 		{
 			query: "SET PATH dummy",
-			err:   errors.New(`trino: query failed (200 OK): "io.prestosql.spi.PrestoException: SET PATH not supported by client"`),
+			err:   errors.New(`trino: query failed (200 OK): "io.trino.spi.TrinoException: SET PATH not supported by client"`),
 		},
 		{
 			query: "RESET SESSION grouped_execution",

--- a/trino/serial.go
+++ b/trino/serial.go
@@ -88,7 +88,7 @@ func Serial(v interface{}) (string, error) {
 	case string:
 		return "'" + strings.Replace(x, "'", "''", -1) + "'", nil
 
-		// TODO - []byte should probably be matched to 'VARBINARY' in presto
+		// TODO - []byte should probably be matched to 'VARBINARY' in trino
 	case []byte:
 		return "", UnsupportedArgError{"[]byte"}
 

--- a/trino/trino.go
+++ b/trino/trino.go
@@ -99,19 +99,19 @@ var (
 )
 
 const (
-	preparedStatementHeader = "X-Presto-Prepared-Statement"
+	preparedStatementHeader = "X-Trino-Prepared-Statement"
 	preparedStatementName   = "_trino_go"
-	trinoUserHeader         = "X-Presto-User"
-	trinoSourceHeader       = "X-Presto-Source"
-	trinoCatalogHeader      = "X-Presto-Catalog"
-	trinoSchemaHeader       = "X-Presto-Schema"
-	trinoSessionHeader      = "X-Presto-Session"
-	trinoSetCatalogHeader   = "X-Presto-Set-Catalog"
-	trinoSetSchemaHeader    = "X-Presto-Set-Schema"
-	trinoSetPathHeader      = "X-Presto-Set-Path"
-	trinoSetSessionHeader   = "X-Presto-Set-Session"
-	trinoClearSessionHeader = "X-Presto-Clear-Session"
-	trinoSetRoleHeader      = "X-Presto-Set-Role"
+	trinoUserHeader         = "X-Trino-User"
+	trinoSourceHeader       = "X-Trino-Source"
+	trinoCatalogHeader      = "X-Trino-Catalog"
+	trinoSchemaHeader       = "X-Trino-Schema"
+	trinoSessionHeader      = "X-Trino-Session"
+	trinoSetCatalogHeader   = "X-Trino-Set-Catalog"
+	trinoSetSchemaHeader    = "X-Trino-Set-Schema"
+	trinoSetPathHeader      = "X-Trino-Set-Path"
+	trinoSetSessionHeader   = "X-Trino-Set-Session"
+	trinoClearSessionHeader = "X-Trino-Clear-Session"
+	trinoSetRoleHeader      = "X-Trino-Set-Role"
 
 	KerberosEnabledConfig    = "KerberosEnabled"
 	kerberosKeytabPathConfig = "KerberosKeytabPath"
@@ -396,7 +396,7 @@ func (c *Conn) newRequest(method, url string, body io.Reader, hs http.Header) (*
 	}
 
 	if c.kerberosEnabled {
-		err = c.kerberosClient.SetSPNEGOHeader(req, "presto/"+req.URL.Hostname())
+		err = c.kerberosClient.SetSPNEGOHeader(req, "trino/"+req.URL.Hostname())
 		if err != nil {
 			return nil, fmt.Errorf("error setting client SPNEGO header: %v", err)
 		}
@@ -907,7 +907,7 @@ func newTypeConverter(typeName string) *typeConverter {
 	}
 }
 
-// parses presto types, e.g. array(varchar(10)) to "array", "varchar"
+// parses Trino types, e.g. array(varchar(10)) to "array", "varchar"
 // TODO: Use queryColumn.TypeSignature instead.
 func parseType(name string) []string {
 	parts := strings.Split(strings.ToLower(name), "(")
@@ -1447,7 +1447,7 @@ func parseNullTimeWithLocation(v string) (NullTime, error) {
 }
 
 // NullTime represents a time.Time value that can be null.
-// The NullTime supports presto's Date, Time and Timestamp data types,
+// The NullTime supports Trino's Date, Time and Timestamp data types,
 // with or without time zone.
 type NullTime struct {
 	Time  time.Time

--- a/trino/trino_test.go
+++ b/trino/trino_test.go
@@ -79,7 +79,7 @@ func TestKerberosConfig(t *testing.T) {
 		SessionProperties:  map[string]string{"query_priority": "1"},
 		KerberosEnabled:    "true",
 		KerberosKeytabPath: "/opt/test.keytab",
-		KerberosPrincipal:  "presto/testhost",
+		KerberosPrincipal:  "trino/testhost",
 		KerberosRealm:      "example.com",
 		KerberosConfigPath: "/etc/krb5.conf",
 		SSLCertPath:        "/tmp/test.cert",
@@ -89,7 +89,7 @@ func TestKerberosConfig(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	want := "https://foobar@localhost:8090?KerberosConfigPath=%2Fetc%2Fkrb5.conf&KerberosEnabled=true&KerberosKeytabPath=%2Fopt%2Ftest.keytab&KerberosPrincipal=presto%2Ftesthost&KerberosRealm=example.com&SSLCertPath=%2Ftmp%2Ftest.cert&session_properties=query_priority%3D1&source=trino-go-client"
+	want := "https://foobar@localhost:8090?KerberosConfigPath=%2Fetc%2Fkrb5.conf&KerberosEnabled=true&KerberosKeytabPath=%2Fopt%2Ftest.keytab&KerberosPrincipal=trino%2Ftesthost&KerberosRealm=example.com&SSLCertPath=%2Ftmp%2Ftest.cert&session_properties=query_priority%3D1&source=trino-go-client"
 	if dsn != want {
 		t.Fatal("unexpected dsn:", dsn)
 	}
@@ -218,7 +218,7 @@ func TestQueryForUsername(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer db.Close()
-	rows, err := db.Query("SELECT current_user", sql.Named("X-Presto-User", string("TestUser")))
+	rows, err := db.Query("SELECT current_user", sql.Named("X-Trino-User", string("TestUser")))
 	if err != nil {
 		t.Fatal("Failed executing query", err.Error())
 	}


### PR DESCRIPTION
Finish rename to Trino, notably use `X-Trino` in HTTP headers.