### PR TITLE
Fix broken role integration test

### DIFF
--- a/trino/integration_test.go
+++ b/trino/integration_test.go
@@ -473,7 +473,7 @@ func TestIntegrationUnsupportedHeader(t *testing.T) {
 		},
 		{
 			query: "SET ROLE dummy",
-			err:   ErrUnsupportedHeader,
+			err:   errors.New(`trino: query failed (200 OK): "io.trino.spi.TrinoException: line 1:1: Role 'dummy' does not exist"`),
 		},
 		{
 			query: "SET PATH dummy",


### PR DESCRIPTION
Version 362 started disallowing to set roles which don't exist. 