### PR TITLE
Support passing slices as query args

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,30 @@ https://user@localhost:8443?session_properties=query_max_run_time=10m,query_prio
 
 ## Data types
 
-The driver supports most Trino data types, except:
+### Query arguments
+
+When passing arguments to queries, the driver supports the following Go data types:
+* integers
+* `bool`
+* `string`
+* slices
+
+It's not yet possible to pass:
+* `nil`
+* `float32` or `float64`
+* `byte`
+* `time.Time` or `time.Duration`
+* `json.RawMessage`
+* maps
+
+To use the unsupported types, pass them as strings and use casts in the query, like so:
+```sql
+SELECT * FROM table WHERE col_double = cast(? AS DOUBLE) OR col_timestamp = CAST(? AS TIMESTAMP)
+```
+
+### Response rows
+
+When reading response rows, the driver supports most Trino data types, except:
 * time and timestamps with precision - all time types are returned as `time.Time`
 * `DECIMAL` - returned as string
 * `IPADDRESS` - returned as string

--- a/trino/trino.go
+++ b/trino/trino.go
@@ -65,6 +65,7 @@ import (
 	"math"
 	"net/http"
 	"net/url"
+	"reflect"
 	"regexp"
 	"sort"
 	"strconv"
@@ -544,9 +545,10 @@ type driverStmt struct {
 }
 
 var (
-	_ driver.Stmt             = &driverStmt{}
-	_ driver.StmtQueryContext = &driverStmt{}
-	_ driver.StmtExecContext  = &driverStmt{}
+	_ driver.Stmt              = &driverStmt{}
+	_ driver.StmtQueryContext  = &driverStmt{}
+	_ driver.StmtExecContext   = &driverStmt{}
+	_ driver.NamedValueChecker = &driverStmt{}
 )
 
 func (st *driverStmt) Close() error {
@@ -581,6 +583,13 @@ func (st *driverStmt) ExecContext(ctx context.Context, args []driver.NamedValue)
 		return nil, err
 	}
 	return rows, nil
+}
+
+func (st *driverStmt) CheckNamedValue(arg *driver.NamedValue) error {
+	if reflect.TypeOf(arg.Value).Kind() == reflect.Slice {
+		return nil
+	}
+	return driver.ErrSkip
 }
 
 type stmtResponse struct {


### PR DESCRIPTION
Fixes #20

If #46 goes in first, I'll add some examples in the README how to pass floats and timestamps to queries, since `float64` and `time.Time` is not supported.