### PR TITLE
Use GoReleaser to create GitHub releases with a changelog

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,36 @@
+name: release
+
+on:
+  push:
+    # run only against tags
+    tags:
+      - '*'
+
+permissions:
+  contents: read
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Fetch all tags
+        run: git fetch --force --tags
+
+      - name: Set up Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: 1.18
+          cache: true
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v3
+        with:
+          distribution: goreleaser
+          version: latest
+          args: release --rm-dist
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 coverage.out
 .idea
+/dist

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,2 @@
+builds:
+- skip: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,3 +7,7 @@ In order to accept your pull request, we need you to [submit a CLA](https://gith
 ## License
 
 By contributing to Trino, you agree that your contributions will be licensed under the [Apache License Version 2.0 (APLv2)](LICENSE).
+
+# Releases
+
+To create a new release, a maintainer with repository write permissions needs to create and push a new git tag.

--- a/README.md
+++ b/README.md
@@ -249,3 +249,7 @@ will receive a `[]interface{}` slice, with values of the following types:
 ## License
 
 As described in the [LICENSE](./LICENSE) file.
+
+## Contributing
+
+For contributing, development, and release guidelines, see [CONTRIBUTING.md](./CONTRIBUTING.md).


### PR DESCRIPTION
Use GoReleaser because it creates nice changelogs. I used it recently in https://github.com/nineinchnick/trino-postgresql-gateway/

I'm not sure if we want the workflows to automatically bump versions and create tags. Is this new workflow self-documenting enough so we'll remember that we only need to create a tag to cut a new release?