### PR TITLE
Disable cache for releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go: ['>=1.18', '1.14']
+        go: ['>=1.19', '1.14']
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,6 @@ jobs:
         uses: actions/setup-go@v3
         with:
           go-version: 1.18
-          cache: true
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.18
+          go-version: 1.19
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v3


### PR DESCRIPTION
Disable cache in the release workflow. I couldn't find any info in Goreleaser docs on how it builds the project and why it wouldn't populate the regular go modules cache. It should work fine for regular CI workflow.

I also bumped the version of go.