### PR TITLE
Concurrent requests

### DIFF
--- a/trino/trino.go
+++ b/trino/trino.go
@@ -43,12 +43,11 @@
 //
 // The driver should be used via the database/sql package:
 //
-//  import "database/sql"
-//  import _ "github.com/trinodb/trino-go-client/trino"
+//	import "database/sql"
+//	import _ "github.com/trinodb/trino-go-client/trino"
 //
-//  dsn := "http://user@localhost:8080?catalog=default&schema=test"
-//  db, err := sql.Open("trino", dsn)
-//
+//	dsn := "http://user@localhost:8080?catalog=default&schema=test"
+//	db, err := sql.Open("trino", dsn)
 package trino
 
 import (
@@ -372,7 +371,6 @@ var customClientRegistry = struct {
 //	}
 //	trino.RegisterCustomClient("foobar", foobarClient)
 //	db, err := sql.Open("trino", "https://user@localhost:8080?custom_client=foobar")
-//
 func RegisterCustomClient(key string, client *http.Client) error {
 	if _, err := strconv.ParseBool(key); err == nil {
 		return fmt.Errorf("trino: custom client key %q is reserved", key)

--- a/trino/trino_test.go
+++ b/trino/trino_test.go
@@ -800,6 +800,7 @@ func TestFetchNoStackOverflow(t *testing.T) {
 			if buf == nil {
 				buf = new(bytes.Buffer)
 				json.NewEncoder(buf).Encode(&stmtResponse{
+					ID:      "fake-query",
 					NextURI: ts.URL + "/v1/statement/20210817_140827_00000_arvdv/1",
 				})
 			}


### PR DESCRIPTION
Introduce two goroutines for making HTTP requests and decoding the JSON payload concurrently. This brings only a minor improvement (see benchmarks below) unless the server can send the `nextUri` as an HTTP header, so the next request can be made immediately, without waiting to decode the payload. 


Before:
```
% go test -v -race -timeout 1m ./... -run=X -bench=. -no_cleanup
goos: darwin
goarch: arm64
pkg: github.com/trinodb/trino-go-client/trino
BenchmarkQuery
BenchmarkQuery-10    	      1	55366793167 ns/op
PASS
ok  	github.com/trinodb/trino-go-client/trino	67.287s
go test -v -race -timeout 1m ./... -run=X -bench=. -no_cleanup  51.59s user 0.88s system 77% cpu 1:07.69 total
```

After:
```
% go test -v -race -timeout 1m ./... -run=X -bench=. -no_cleanup
goos: darwin
goarch: arm64
pkg: github.com/trinodb/trino-go-client/trino
BenchmarkQuery
BenchmarkQuery-10    	      1	48234415166 ns/op
PASS
ok  	github.com/trinodb/trino-go-client/trino	48.676s
go test -v -race -timeout 1m ./... -run=X -bench=. -no_cleanup  51.94s user 0.89s system 107% cpu 49.096 total
```