### PR TITLE
Change the fieldName field type from string to rowFieldName struct

### DIFF
--- a/trino/trino.go
+++ b/trino/trino.go
@@ -1070,8 +1070,12 @@ type queryColumn struct {
 type queryData []interface{}
 
 type namedTypeSignature struct {
-	FieldName     string        `json:"fieldName"`
+	FieldName     rowFieldName  `json:"fieldName"`
 	TypeSignature typeSignature `json:"typeSignature"`
+}
+
+type rowFieldName struct {
+	Name string `json:"name"`
 }
 
 type typeSignature struct {

--- a/trino/trino_test.go
+++ b/trino/trino_test.go
@@ -394,6 +394,7 @@ func TestQueryColumns(t *testing.T) {
   map(array['a'], array[1]) AS map,
   array[map(array['a'], array[1]), map(array['b'], array[2])] AS marray,
   row('a', 1) AS row,
+  cast(row('a', 1.23) AS row(x varchar, y double)) AS named_row,
   ipaddress '10.0.0.1' AS ip`)
 	require.NoError(t, err, "Failed executing query")
 	assert.NotNil(t, rows)
@@ -401,7 +402,7 @@ func TestQueryColumns(t *testing.T) {
 	columns, err := rows.Columns()
 	require.NoError(t, err, "Failed reading result columns")
 
-	assert.Equal(t, 31, len(columns), "Expected 31 result column")
+	assert.Equal(t, 32, len(columns), "Expected 32 result column")
 	expectedNames := []string{
 		"bool",
 		"tinyint",
@@ -433,6 +434,7 @@ func TestQueryColumns(t *testing.T) {
 		"map",
 		"marray",
 		"row",
+		"named_row",
 		"ip",
 	}
 	assert.Equal(t, expectedNames, columns)
@@ -440,7 +442,7 @@ func TestQueryColumns(t *testing.T) {
 	columnTypes, err := rows.ColumnTypes()
 	require.NoError(t, err, "Failed reading result column types")
 
-	assert.Equal(t, 31, len(columnTypes), "Expected 31 result column type")
+	assert.Equal(t, 32, len(columnTypes), "Expected 32 result column type")
 
 	type columnType struct {
 		typeName  string
@@ -723,6 +725,15 @@ func TestQueryColumns(t *testing.T) {
 			reflect.TypeOf(new(interface{})).Elem(),
 		},
 		{
+			"ROW(X VARCHAR, Y DOUBLE)",
+			false,
+			0,
+			0,
+			false,
+			0,
+			reflect.TypeOf(new(interface{})).Elem(),
+		},
+		{
 			"IPADDRESS",
 			false,
 			0,
@@ -732,7 +743,7 @@ func TestQueryColumns(t *testing.T) {
 			reflect.TypeOf(sql.NullString{}),
 		},
 	}
-	actualTypes := make([]columnType, 31)
+	actualTypes := make([]columnType, 32)
 	for i, column := range columnTypes {
 		actualTypes[i].typeName = column.DatabaseTypeName()
 		actualTypes[i].precision, actualTypes[i].scale, actualTypes[i].hasScale = column.DecimalSize()


### PR DESCRIPTION
### Situation

If a name is assigned to a ROW type, the following error occurs.

<img width="1097" alt="스크린샷 2022-11-14 오후 11 17 38" src="https://user-images.githubusercontent.com/62536685/201684518-5316f179-7c8e-44fd-a099-c8c02b25c9ba.png">

The fieldName field is not in the form of a simple string, but in the form of JSON nested objects with a field called name.

```json
{
    "rawType":"row",
    "arguments":[
        {
            "kind":"NAMED_TYPE",
            "value":{
                "fieldName":{"name":"x"},
                "typeSignature":{"rawType":"varchar","arguments":[{"kind":"LONG","value":2147483647}]}
            }
        },
        {
            "kind":"NAMED_TYPE",
            "value":{
                "fieldName":{"name":"y"},
                "typeSignature":{"rawType":"double","arguments":[]}
            }
        }
    ]
}
```

### Reference Source
* NamedTypeSignature : https://github.com/trinodb/trino/blob/fe608f2723842037ff620d612a706900e79c52c8/core/trino-spi/src/main/java/io/trino/spi/type/NamedTypeSignature.java#L27
* RowFieldName: https://github.com/trinodb/trino/blob/fe608f2723842037ff620d612a706900e79c52c8/core/trino-spi/src/main/java/io/trino/spi/type/RowFieldName.java#L25