### PR TITLE
Support times better

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,12 +198,17 @@ When passing arguments to queries, the driver supports the following Go data typ
 * `string`
 * slices
 * `trino.Numeric` - a string representation of a number
+* `time.Time` - passed to Trino as a timestamp with a time zone
+* the result of `trino.Date(year, month, day)` - passed to Trino as a date
+* the result of `trino.Time(hour, minute, second, nanosecond)` - passed to Trino as a time without a time zone
+* the result of `trino.TimeTz(hour, minute, second, nanosecond, location)` - passed to Trino as a time with a time zone
+* the result of `trino.Timestamp(year, month, day, hour, minute, second, nanosecond)` - passed to Trino as a timestamp without a time zone
 
 It's not yet possible to pass:
 * `nil`
 * `float32` or `float64`
 * `byte`
-* `time.Time` or `time.Duration`
+* `time.Duration`
 * `json.RawMessage`
 * maps
 
@@ -215,7 +220,11 @@ SELECT * FROM table WHERE col_double = cast(? AS DOUBLE) OR col_timestamp = CAST
 ### Response rows
 
 When reading response rows, the driver supports most Trino data types, except:
-* time and timestamps with precision - all time types are returned as `time.Time`
+* time and timestamps with precision - all time types are returned as `time.Time`.
+  All precisions up to nanoseconds (`TIMESTAMP(9)` or `TIME(9)`) are supported (since
+  this is the maximum precision Golang's `time.Time` supports). If a query returns columns
+  defined with a greater precision, use `CAST` to reduce the returned precision, or convert the
+  value to a string that then can be parsed manually.
 * `DECIMAL` - returned as string
 * `IPADDRESS` - returned as string
 * `INTERVAL YEAR TO MONTH` and `INTERVAL DAY TO SECOND` - returned as string

--- a/trino/integration_test.go
+++ b/trino/integration_test.go
@@ -422,7 +422,7 @@ func TestIntegrationArgsConversion(t *testing.T) {
 			AND col_big = ?
 			AND col_real = cast(? as real)
 			AND col_double = cast(? as double)
-			AND col_ts = cast(? as timestamp)
+			AND col_ts = ?
 			AND col_varchar = ?
 			AND col_array = ?`,
 		int16(1),
@@ -431,7 +431,7 @@ func TestIntegrationArgsConversion(t *testing.T) {
 		int64(1),
 		Numeric("1"),
 		Numeric("1"),
-		"2017-07-10 01:02:03.004 UTC",
+		time.Date(2017, 7, 10, 1, 2, 3, 4*1000000, time.UTC),
 		"string",
 		[]string{"A", "B"}).Scan(&value)
 	if err != nil {

--- a/trino/serial_test.go
+++ b/trino/serial_test.go
@@ -14,9 +14,16 @@
 
 package trino
 
-import "testing"
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
 
 func TestSerial(t *testing.T) {
+	paris, err := time.LoadLocation("Europe/Paris")
+	require.NoError(t, err)
 	scenarios := []struct {
 		name           string
 		value          interface{}
@@ -112,6 +119,46 @@ func TestSerial(t *testing.T) {
 			name:           "bool false",
 			value:          false,
 			expectedSerial: "false",
+		},
+		{
+			name:           "date",
+			value:          Date(2017, 7, 10),
+			expectedSerial: "DATE '2017-07-10'",
+		},
+		{
+			name:           "time without timezone",
+			value:          Time(11, 34, 25, 123456),
+			expectedSerial: "TIME '11:34:25.000123456'",
+		},
+		{
+			name:           "time with timezone",
+			value:          TimeTz(11, 34, 25, 123456, time.FixedZone("test zone", +2*3600)),
+			expectedSerial: "TIME '11:34:25.000123456 +02:00'",
+		},
+		{
+			name:           "time with timezone",
+			value:          TimeTz(11, 34, 25, 123456, nil),
+			expectedSerial: "TIME '11:34:25.000123456 Z'",
+		},
+		{
+			name:           "timestamp without timezone",
+			value:          Timestamp(2017, 7, 10, 11, 34, 25, 123456),
+			expectedSerial: "TIMESTAMP '2017-07-10 11:34:25.000123456'",
+		},
+		{
+			name:           "timestamp with time zone in Fixed Zone",
+			value:          time.Date(2017, 7, 10, 11, 34, 25, 123456, time.FixedZone("test zone", +2*3600)),
+			expectedSerial: "TIMESTAMP '2017-07-10 11:34:25.000123456 +02:00'",
+		},
+		{
+			name:           "timestamp with time zone in Named Zone",
+			value:          time.Date(2017, 7, 10, 11, 34, 25, 123456, paris),
+			expectedSerial: "TIMESTAMP '2017-07-10 11:34:25.000123456 +02:00'",
+		},
+		{
+			name:           "timestamp with time zone in UTC",
+			value:          time.Date(2017, 7, 10, 11, 34, 25, 123456, time.UTC),
+			expectedSerial: "TIMESTAMP '2017-07-10 11:34:25.000123456 Z'",
 		},
 		{
 			name:          "nil",


### PR DESCRIPTION
Add support for full precision of subseconds, so `PARAMETRIC_DATETIME` works properly.

Add type wrappers in the manner of `Numeric` for the various date/time data types, so we can avoid casts and not leak the accepted formats to the client.