### PR TITLE
Don't panic if driverRows.Next is called after Close

### DIFF
--- a/trino/trino.go
+++ b/trino/trino.go
@@ -1139,7 +1139,11 @@ func (qr *driverRows) fetch() error {
 				return nil
 			}
 		case err = <-qr.stmt.errors:
-			if err == context.Canceled {
+			if err == nil {
+				// Channel was closed, which means the statement
+				// or rows were closed.
+				err = io.EOF
+			} else if err == context.Canceled {
 				qr.Close()
 			}
 			qr.err = err


### PR DESCRIPTION
Previously this would panic with an index out of range error. Which was misleading as the indexing itself wasn't the problem. The problem was that fetch returns a `nil` error if the error channel was closed, which led the `Next` function to believe there was more data ready to be processed, but this was not the case.

The error channel is only closed if Close is called on `driverRows` or `driverStmt`, so this panic was caused by a premature closing of the rows or statement, but that hard to tell from the panic message.

This commit changes removes the panic and instead returns an `io.EOF` error if we detect that fetch was called on a closed statement or rows.

Closes #65.