### PR TITLE
Support bytes

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,18 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Launch Package",
+            "type": "go",
+            "request": "launch",
+            "mode": "auto",
+            "program": "${fileDirname}",
+            "args": [
+                "-short"
+            ]
+        }
+    ]
+}

--- a/trino/serial.go
+++ b/trino/serial.go
@@ -15,6 +15,7 @@
 package trino
 
 import (
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"reflect"
@@ -147,9 +148,8 @@ func Serial(v interface{}) (string, error) {
 	case string:
 		return "'" + strings.Replace(x, "'", "''", -1) + "'", nil
 
-		// TODO - []byte should probably be matched to 'VARBINARY' in trino
 	case []byte:
-		return "", UnsupportedArgError{"[]byte"}
+		return "X'" + strings.ToUpper(hex.EncodeToString(x)) + "'", nil
 
 	case trinoDate:
 		return fmt.Sprintf("DATE '%04d-%02d-%02d'", x.year, x.month, x.day), nil

--- a/trino/serial_test.go
+++ b/trino/serial_test.go
@@ -121,6 +121,16 @@ func TestSerial(t *testing.T) {
 			expectedSerial: "false",
 		},
 		{
+			name:           "bytes",
+			value:          []byte{1, 255},
+			expectedSerial: "X'01FF'",
+		},
+		{
+			name:           "empty bytes",
+			value:          []byte{},
+			expectedSerial: "X''",
+		},
+		{
 			name:           "date",
 			value:          Date(2017, 7, 10),
 			expectedSerial: "DATE '2017-07-10'",


### PR DESCRIPTION
translate bytes to 'VARBINARY' in trino so we can filter column which type is ‘VARBINARY’ by bytes