### PR TITLE
Move tests to a separate package

### DIFF
--- a/trino/integration_test.go
+++ b/trino/integration_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package trino
+package trino_test
 
 import (
 	"context"
@@ -29,6 +29,7 @@ import (
 	"time"
 
 	dt "github.com/ory/dockertest/v3"
+	"github.com/trinodb/trino-go-client/trino"
 )
 
 var (
@@ -59,8 +60,8 @@ var (
 
 func TestMain(m *testing.M) {
 	flag.Parse()
-	DefaultQueryTimeout = *integrationServerQueryTimeout
-	DefaultCancelQueryTimeout = *integrationServerQueryTimeout
+	trino.DefaultQueryTimeout = *integrationServerQueryTimeout
+	trino.DefaultCancelQueryTimeout = *integrationServerQueryTimeout
 
 	var err error
 	if *integrationServerFlag == "" && !testing.Short() {
@@ -206,7 +207,7 @@ func TestIntegrationSelectFailedQuery(t *testing.T) {
 		rows.Close()
 		t.Fatal("query to invalid catalog succeeded")
 	}
-	_, ok := err.(*ErrQueryFailed)
+	_, ok := err.(*trino.ErrQueryFailed)
 	if !ok {
 		t.Fatal("unexpected error:", err)
 	}
@@ -342,7 +343,7 @@ func TestIntegrationSessionProperties(t *testing.T) {
 }
 
 func TestIntegrationTypeConversion(t *testing.T) {
-	err := RegisterCustomClient("uncompressed", &http.Client{Transport: &http.Transport{DisableCompression: true}})
+	err := trino.RegisterCustomClient("uncompressed", &http.Client{Transport: &http.Transport{DisableCompression: true}})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -351,20 +352,20 @@ func TestIntegrationTypeConversion(t *testing.T) {
 	db := integrationOpen(t, dsn)
 	var (
 		goTime            time.Time
-		nullTime          NullTime
+		nullTime          trino.NullTime
 		goString          string
 		nullString        sql.NullString
-		nullStringSlice   NullSliceString
-		nullStringSlice2  NullSlice2String
-		nullStringSlice3  NullSlice3String
-		nullInt64Slice    NullSliceInt64
-		nullInt64Slice2   NullSlice2Int64
-		nullInt64Slice3   NullSlice3Int64
-		nullFloat64Slice  NullSliceFloat64
-		nullFloat64Slice2 NullSlice2Float64
-		nullFloat64Slice3 NullSlice3Float64
+		nullStringSlice   trino.NullSliceString
+		nullStringSlice2  trino.NullSlice2String
+		nullStringSlice3  trino.NullSlice3String
+		nullInt64Slice    trino.NullSliceInt64
+		nullInt64Slice2   trino.NullSlice2Int64
+		nullInt64Slice3   trino.NullSlice3Int64
+		nullFloat64Slice  trino.NullSliceFloat64
+		nullFloat64Slice2 trino.NullSlice2Float64
+		nullFloat64Slice3 trino.NullSlice3Float64
 		goMap             map[string]interface{}
-		nullMap           NullMap
+		nullMap           trino.NullMap
 		goRow             []interface{}
 	)
 	err = db.QueryRow(`
@@ -439,8 +440,8 @@ func TestIntegrationArgsConversion(t *testing.T) {
 		int16(1),
 		int32(1),
 		int64(1),
-		Numeric("1"),
-		Numeric("1"),
+		trino.Numeric("1"),
+		trino.Numeric("1"),
 		time.Date(2017, 7, 10, 1, 2, 3, 4*1000000, time.UTC),
 		"string",
 		[]string{"A", "B"}).Scan(&value)
@@ -542,7 +543,7 @@ func TestIntegrationQueryNextAfterClose(t *testing.T) {
 	// panic if we call driverRows.Next after we closed the driverStmt.
 
 	ctx := context.Background()
-	conn, err := (&Driver{}).Open(*integrationServerFlag)
+	conn, err := (&trino.Driver{}).Open(*integrationServerFlag)
 	defer conn.Close()
 
 	stmt, err := conn.(driver.ConnPrepareContext).PrepareContext(ctx, "SELECT 1")
@@ -628,7 +629,7 @@ func TestIntegrationUnsupportedHeader(t *testing.T) {
 }
 
 func TestIntegrationQueryContextCancellation(t *testing.T) {
-	err := RegisterCustomClient("uncompressed", &http.Client{Transport: &http.Transport{DisableCompression: true}})
+	err := trino.RegisterCustomClient("uncompressed", &http.Client{Transport: &http.Transport{DisableCompression: true}})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/trino/integration_tls_test.go
+++ b/trino/integration_tls_test.go
@@ -12,9 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build go1.9
 // +build go1.9
 
-package trino
+package trino_test
 
 import (
 	"bytes"
@@ -28,6 +29,8 @@ import (
 	"strings"
 	"sync"
 	"testing"
+
+	"github.com/trinodb/trino-go-client/trino"
 )
 
 func TestIntegrationTLS(t *testing.T) {
@@ -36,8 +39,8 @@ func TestIntegrationTLS(t *testing.T) {
 	}
 	proxyServer := newTLSReverseProxy(t)
 	defer proxyServer.Close()
-	RegisterCustomClient("test_tls", proxyServer.Client())
-	defer DeregisterCustomClient("test_tls")
+	trino.RegisterCustomClient("test_tls", proxyServer.Client())
+	defer trino.DeregisterCustomClient("test_tls")
 	dsn := proxyServer.URL + "?custom_client=test_tls"
 	testSimpleQuery(t, dsn)
 }
@@ -48,14 +51,14 @@ func TestIntegrationInsecureTLS(t *testing.T) {
 	}
 	proxyServer := newTLSReverseProxy(t)
 	defer proxyServer.Close()
-	RegisterCustomClient("test_insecure_tls", &http.Client{
+	trino.RegisterCustomClient("test_insecure_tls", &http.Client{
 		Transport: &http.Transport{
 			TLSClientConfig: &tls.Config{
 				InsecureSkipVerify: true,
 			},
 		},
 	})
-	defer DeregisterCustomClient("test_insecure_tls")
+	defer trino.DeregisterCustomClient("test_insecure_tls")
 	dsn := proxyServer.URL + "?custom_client=test_insecure_tls"
 	testSimpleQuery(t, dsn)
 }

--- a/trino/serial_test.go
+++ b/trino/serial_test.go
@@ -12,13 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package trino
+package trino_test
 
 import (
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"github.com/trinodb/trino-go-client/trino"
 )
 
 func TestSerial(t *testing.T) {
@@ -102,12 +103,12 @@ func TestSerial(t *testing.T) {
 		},
 		{
 			name:           "valid Numeric",
-			value:          Numeric("10"),
+			value:          trino.Numeric("10"),
 			expectedSerial: "10",
 		},
 		{
 			name:          "invalid Numeric",
-			value:         Numeric("not-a-number"),
+			value:         trino.Numeric("not-a-number"),
 			expectedError: true,
 		},
 		{
@@ -122,27 +123,27 @@ func TestSerial(t *testing.T) {
 		},
 		{
 			name:           "date",
-			value:          Date(2017, 7, 10),
+			value:          trino.Date(2017, 7, 10),
 			expectedSerial: "DATE '2017-07-10'",
 		},
 		{
 			name:           "time without timezone",
-			value:          Time(11, 34, 25, 123456),
+			value:          trino.Time(11, 34, 25, 123456),
 			expectedSerial: "TIME '11:34:25.000123456'",
 		},
 		{
 			name:           "time with timezone",
-			value:          TimeTz(11, 34, 25, 123456, time.FixedZone("test zone", +2*3600)),
+			value:          trino.TimeTz(11, 34, 25, 123456, time.FixedZone("test zone", +2*3600)),
 			expectedSerial: "TIME '11:34:25.000123456 +02:00'",
 		},
 		{
 			name:           "time with timezone",
-			value:          TimeTz(11, 34, 25, 123456, nil),
+			value:          trino.TimeTz(11, 34, 25, 123456, nil),
 			expectedSerial: "TIME '11:34:25.000123456 Z'",
 		},
 		{
 			name:           "timestamp without timezone",
-			value:          Timestamp(2017, 7, 10, 11, 34, 25, 123456),
+			value:          trino.Timestamp(2017, 7, 10, 11, 34, 25, 123456),
 			expectedSerial: "TIMESTAMP '2017-07-10 11:34:25.000123456'",
 		},
 		{
@@ -191,7 +192,7 @@ func TestSerial(t *testing.T) {
 		scenario := scenarios[i]
 
 		t.Run(scenario.name, func(t *testing.T) {
-			s, err := Serial(scenario.value)
+			s, err := trino.Serial(scenario.value)
 			if err != nil {
 				if scenario.expectedError {
 					return

--- a/trino/types_test.go
+++ b/trino/types_test.go
@@ -1,0 +1,362 @@
+// Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package trino
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTypeConversion(t *testing.T) {
+	utc, err := time.LoadLocation("UTC")
+	require.NoError(t, err)
+	paris, err := time.LoadLocation("Europe/Paris")
+	require.NoError(t, err)
+
+	testcases := []struct {
+		DataType                   string
+		RawType                    string
+		Arguments                  []typeArgument
+		ResponseUnmarshalledSample interface{}
+		ExpectedGoValue            interface{}
+	}{
+		{
+			DataType:                   "boolean",
+			RawType:                    "boolean",
+			ResponseUnmarshalledSample: true,
+			ExpectedGoValue:            true,
+		},
+		{
+			DataType:                   "varchar(1)",
+			RawType:                    "varchar",
+			ResponseUnmarshalledSample: "hello",
+			ExpectedGoValue:            "hello",
+		},
+		{
+			DataType:                   "bigint",
+			RawType:                    "bigint",
+			ResponseUnmarshalledSample: json.Number("1234516165077230279"),
+			ExpectedGoValue:            int64(1234516165077230279),
+		},
+		{
+			DataType:                   "double",
+			RawType:                    "double",
+			ResponseUnmarshalledSample: json.Number("1.0"),
+			ExpectedGoValue:            float64(1),
+		},
+		{
+			DataType:                   "date",
+			RawType:                    "date",
+			ResponseUnmarshalledSample: "2017-07-10",
+			ExpectedGoValue:            time.Date(2017, 7, 10, 0, 0, 0, 0, time.Local),
+		},
+		{
+			DataType:                   "time",
+			RawType:                    "time",
+			ResponseUnmarshalledSample: "01:02:03.000",
+			ExpectedGoValue:            time.Date(0, 1, 1, 1, 2, 3, 0, time.Local),
+		},
+		{
+			DataType:                   "time with time zone",
+			RawType:                    "time with time zone",
+			ResponseUnmarshalledSample: "01:02:03.000 UTC",
+			ExpectedGoValue:            time.Date(0, 1, 1, 1, 2, 3, 0, utc),
+		},
+		{
+			DataType:                   "time with time zone",
+			RawType:                    "time with time zone",
+			ResponseUnmarshalledSample: "01:02:03.000 +03:00",
+			ExpectedGoValue:            time.Date(0, 1, 1, 1, 2, 3, 0, time.FixedZone("", 3*3600)),
+		},
+		{
+			DataType:                   "time with time zone",
+			RawType:                    "time with time zone",
+			ResponseUnmarshalledSample: "01:02:03.000+03:00",
+			ExpectedGoValue:            time.Date(0, 1, 1, 1, 2, 3, 0, time.FixedZone("", 3*3600)),
+		},
+		{
+			DataType:                   "time with time zone",
+			RawType:                    "time with time zone",
+			ResponseUnmarshalledSample: "01:02:03.000 -05:00",
+			ExpectedGoValue:            time.Date(0, 1, 1, 1, 2, 3, 0, time.FixedZone("", -5*3600)),
+		},
+		{
+			DataType:                   "time with time zone",
+			RawType:                    "time with time zone",
+			ResponseUnmarshalledSample: "01:02:03.000-05:00",
+			ExpectedGoValue:            time.Date(0, 1, 1, 1, 2, 3, 0, time.FixedZone("", -5*3600)),
+		},
+		{
+			DataType:                   "time",
+			RawType:                    "time",
+			ResponseUnmarshalledSample: "01:02:03.123456789",
+			ExpectedGoValue:            time.Date(0, 1, 1, 1, 2, 3, 123456789, time.Local),
+		},
+		{
+			DataType:                   "time with time zone",
+			RawType:                    "time with time zone",
+			ResponseUnmarshalledSample: "01:02:03.123456789 UTC",
+			ExpectedGoValue:            time.Date(0, 1, 1, 1, 2, 3, 123456789, utc),
+		},
+		{
+			DataType:                   "time with time zone",
+			RawType:                    "time with time zone",
+			ResponseUnmarshalledSample: "01:02:03.123456789 +03:00",
+			ExpectedGoValue:            time.Date(0, 1, 1, 1, 2, 3, 123456789, time.FixedZone("", 3*3600)),
+		},
+		{
+			DataType:                   "time with time zone",
+			RawType:                    "time with time zone",
+			ResponseUnmarshalledSample: "01:02:03.123456789+03:00",
+			ExpectedGoValue:            time.Date(0, 1, 1, 1, 2, 3, 123456789, time.FixedZone("", 3*3600)),
+		},
+		{
+			DataType:                   "time with time zone",
+			RawType:                    "time with time zone",
+			ResponseUnmarshalledSample: "01:02:03.123456789 -05:00",
+			ExpectedGoValue:            time.Date(0, 1, 1, 1, 2, 3, 123456789, time.FixedZone("", -5*3600)),
+		},
+		{
+			DataType:                   "time with time zone",
+			RawType:                    "time with time zone",
+			ResponseUnmarshalledSample: "01:02:03.123456789-05:00",
+			ExpectedGoValue:            time.Date(0, 1, 1, 1, 2, 3, 123456789, time.FixedZone("", -5*3600)),
+		},
+		{
+			DataType:                   "time with time zone",
+			RawType:                    "time with time zone",
+			ResponseUnmarshalledSample: "01:02:03.123456789 Europe/Paris",
+			ExpectedGoValue:            time.Date(0, 1, 1, 1, 2, 3, 123456789, paris),
+		},
+		{
+			DataType:                   "timestamp",
+			RawType:                    "timestamp",
+			ResponseUnmarshalledSample: "2017-07-10 01:02:03.000",
+			ExpectedGoValue:            time.Date(2017, 7, 10, 1, 2, 3, 0, time.Local),
+		},
+		{
+			DataType:                   "timestamp with time zone",
+			RawType:                    "timestamp with time zone",
+			ResponseUnmarshalledSample: "2017-07-10 01:02:03.000 UTC",
+			ExpectedGoValue:            time.Date(2017, 7, 10, 1, 2, 3, 0, utc),
+		},
+		{
+			DataType:                   "timestamp with time zone",
+			RawType:                    "timestamp with time zone",
+			ResponseUnmarshalledSample: "2017-07-10 01:02:03.000 +03:00",
+			ExpectedGoValue:            time.Date(2017, 7, 10, 1, 2, 3, 0, time.FixedZone("", 3*3600)),
+		},
+		{
+			DataType:                   "timestamp with time zone",
+			RawType:                    "timestamp with time zone",
+			ResponseUnmarshalledSample: "2017-07-10 01:02:03.000+03:00",
+			ExpectedGoValue:            time.Date(2017, 7, 10, 1, 2, 3, 0, time.FixedZone("", 3*3600)),
+		},
+		{
+			DataType:                   "timestamp with time zone",
+			RawType:                    "timestamp with time zone",
+			ResponseUnmarshalledSample: "2017-07-10 01:02:03.000 -04:00",
+			ExpectedGoValue:            time.Date(2017, 7, 10, 1, 2, 3, 0, time.FixedZone("", -4*3600)),
+		},
+		{
+			DataType:                   "timestamp with time zone",
+			RawType:                    "timestamp with time zone",
+			ResponseUnmarshalledSample: "2017-07-10 01:02:03.000-04:00",
+			ExpectedGoValue:            time.Date(2017, 7, 10, 1, 2, 3, 0, time.FixedZone("", -4*3600)),
+		},
+		{
+			DataType:                   "timestamp",
+			RawType:                    "timestamp",
+			ResponseUnmarshalledSample: "2017-07-10 01:02:03.123456789",
+			ExpectedGoValue:            time.Date(2017, 7, 10, 1, 2, 3, 123456789, time.Local),
+		},
+		{
+			DataType:                   "timestamp with time zone",
+			RawType:                    "timestamp with time zone",
+			ResponseUnmarshalledSample: "2017-07-10 01:02:03.123456789 UTC",
+			ExpectedGoValue:            time.Date(2017, 7, 10, 1, 2, 3, 123456789, utc),
+		},
+		{
+			DataType:                   "timestamp with time zone",
+			RawType:                    "timestamp with time zone",
+			ResponseUnmarshalledSample: "2017-07-10 01:02:03.123456789 +03:00",
+			ExpectedGoValue:            time.Date(2017, 7, 10, 1, 2, 3, 123456789, time.FixedZone("", 3*3600)),
+		},
+		{
+			DataType:                   "timestamp with time zone",
+			RawType:                    "timestamp with time zone",
+			ResponseUnmarshalledSample: "2017-07-10 01:02:03.123456789+03:00",
+			ExpectedGoValue:            time.Date(2017, 7, 10, 1, 2, 3, 123456789, time.FixedZone("", 3*3600)),
+		},
+		{
+			DataType:                   "timestamp with time zone",
+			RawType:                    "timestamp with time zone",
+			ResponseUnmarshalledSample: "2017-07-10 01:02:03.123456789 -04:00",
+			ExpectedGoValue:            time.Date(2017, 7, 10, 1, 2, 3, 123456789, time.FixedZone("", -4*3600)),
+		},
+		{
+			DataType:                   "timestamp with time zone",
+			RawType:                    "timestamp with time zone",
+			ResponseUnmarshalledSample: "2017-07-10 01:02:03.123456789-04:00",
+			ExpectedGoValue:            time.Date(2017, 7, 10, 1, 2, 3, 123456789, time.FixedZone("", -4*3600)),
+		},
+		{
+			DataType:                   "timestamp with time zone",
+			RawType:                    "timestamp with time zone",
+			ResponseUnmarshalledSample: "2017-07-10 01:02:03.123456789 Europe/Paris",
+			ExpectedGoValue:            time.Date(2017, 7, 10, 1, 2, 3, 123456789, paris),
+		},
+		{
+			DataType: "map(varchar,varchar)",
+			RawType:  "map",
+			Arguments: []typeArgument{
+				{
+					Kind: "NAMED_TYPE",
+					namedTypeSignature: namedTypeSignature{
+						TypeSignature: typeSignature{
+							RawType: "varchar",
+						},
+					},
+				},
+				{
+					Kind: "NAMED_TYPE",
+					namedTypeSignature: namedTypeSignature{
+						TypeSignature: typeSignature{
+							RawType: "varchar",
+						},
+					},
+				},
+			},
+			ResponseUnmarshalledSample: nil,
+			ExpectedGoValue:            nil,
+		},
+		{
+			// arrays return data as-is for slice scanners
+			DataType: "array(varchar)",
+			RawType:  "array",
+			Arguments: []typeArgument{
+				{
+					Kind: "NAMED_TYPE",
+					namedTypeSignature: namedTypeSignature{
+						TypeSignature: typeSignature{
+							RawType: "varchar",
+						},
+					},
+				},
+			},
+			ResponseUnmarshalledSample: nil,
+			ExpectedGoValue:            nil,
+		},
+		{
+			// rows return data as-is for slice scanners
+			DataType: "row(int, varchar(1), timestamp, array(varchar(1)))",
+			RawType:  "row",
+			Arguments: []typeArgument{
+				{
+					Kind: "NAMED_TYPE",
+					namedTypeSignature: namedTypeSignature{
+						TypeSignature: typeSignature{
+							RawType: "integer",
+						},
+					},
+				},
+				{
+					Kind: "NAMED_TYPE",
+					namedTypeSignature: namedTypeSignature{
+						TypeSignature: typeSignature{
+							RawType: "varchar",
+							Arguments: []typeArgument{
+								{
+									Kind: "LONG",
+									long: 1,
+								},
+							},
+						},
+					},
+				},
+				{
+					Kind: "NAMED_TYPE",
+					namedTypeSignature: namedTypeSignature{
+						TypeSignature: typeSignature{
+							RawType: "timestamp",
+						},
+					},
+				},
+				{
+					Kind: "NAMED_TYPE",
+					namedTypeSignature: namedTypeSignature{
+						TypeSignature: typeSignature{
+							RawType: "array",
+							Arguments: []typeArgument{
+								{
+									Kind: "TYPE",
+									typeSignature: typeSignature{
+										RawType: "varchar",
+										Arguments: []typeArgument{
+											{
+												Kind: "LONG",
+												long: 1,
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			ResponseUnmarshalledSample: []interface{}{
+				json.Number("1"),
+				"a",
+				"2017-07-10 01:02:03.000 UTC",
+				[]interface{}{"b"},
+			},
+			ExpectedGoValue: []interface{}{
+				json.Number("1"),
+				"a",
+				"2017-07-10 01:02:03.000 UTC",
+				[]interface{}{"b"},
+			},
+		},
+	}
+
+	for _, tc := range testcases {
+		converter, err := newTypeConverter(tc.DataType, typeSignature{RawType: tc.RawType, Arguments: tc.Arguments})
+		assert.NoError(t, err)
+
+		t.Run(tc.DataType+":nil", func(t *testing.T) {
+			_, err := converter.ConvertValue(nil)
+			assert.NoError(t, err)
+		})
+
+		t.Run(tc.DataType+":bogus", func(t *testing.T) {
+			_, err := converter.ConvertValue(struct{}{})
+			assert.Error(t, err, "bogus data scanned with no error")
+		})
+
+		t.Run(tc.DataType+":sample", func(t *testing.T) {
+			v, err := converter.ConvertValue(tc.ResponseUnmarshalledSample)
+			require.NoError(t, err)
+
+			require.Equal(t,
+				v, tc.ExpectedGoValue,
+				"unexpected data from sample:\nhave %+v\nwant %+v", v, tc.ExpectedGoValue)
+		})
+	}
+}


### PR DESCRIPTION
Having tests in a separate package makes it easier to ensure we're testing public APIs, so how the driver is actually used.

I did this to verify #79, but it doesn't actually change anything in `go.mod` of a program using this driver.