### PR TITLE
Support reading float literals returned as strings

### DIFF
--- a/trino/integration_test.go
+++ b/trino/integration_test.go
@@ -347,7 +347,7 @@ func TestIntegrationTypeConversion(t *testing.T) {
 		t.Fatal(err)
 	}
 	dsn := *integrationServerFlag
-	dsn += "?session_properties=parse_decimal_literals_as_double=true&custom_client=uncompressed"
+	dsn += "?custom_client=uncompressed"
 	db := integrationOpen(t, dsn)
 	var (
 		goTime            time.Time
@@ -410,7 +410,6 @@ func TestIntegrationTypeConversion(t *testing.T) {
 
 func TestIntegrationArgsConversion(t *testing.T) {
 	dsn := *integrationServerFlag
-	dsn += "?session_properties=parse_decimal_literals_as_double=true"
 	db := integrationOpen(t, dsn)
 	value := 0
 	err := db.QueryRow(`

--- a/trino/trino.go
+++ b/trino/trino.go
@@ -1808,7 +1808,7 @@ func scanNullFloat64(v interface{}) (sql.NullFloat64, error) {
 	if ok {
 		vFloat, err := vNumber.Float64()
 		if err != nil {
-			return sql.NullFloat64{}, fmt.Errorf("cannot convert %v (%T) to float64", vNumber, vNumber)
+			return sql.NullFloat64{}, fmt.Errorf("cannot convert %v (%T) to float64: %w", vNumber, vNumber, err)
 		}
 		return sql.NullFloat64{Valid: true, Float64: vFloat}, nil
 	}
@@ -1820,7 +1820,15 @@ func scanNullFloat64(v interface{}) (sql.NullFloat64, error) {
 	case "-Infinity":
 		return sql.NullFloat64{Valid: true, Float64: math.Inf(-1)}, nil
 	default:
-		return sql.NullFloat64{}, fmt.Errorf("cannot convert %v (%T) to float64", v, v)
+		vString, ok := v.(string)
+		if !ok {
+			return sql.NullFloat64{}, fmt.Errorf("cannot convert %v (%T) to float64", v, v)
+		}
+		vFloat, err := strconv.ParseFloat(vString, 64)
+		if err != nil {
+			return sql.NullFloat64{}, fmt.Errorf("cannot convert %v (%T) to float64: %w", v, v, err)
+		}
+		return sql.NullFloat64{Valid: true, Float64: vFloat}, nil
 	}
 }
 


### PR DESCRIPTION
Trino 428 removed the deprecated `parse_decimal_literals_as_double` property. Without this, the server to returns decimal literals as strings, not floats. Support reading such values when scanning results.

Ref: https://github.com/trinodb/trino/pull/19166