### PR TITLE
Support nil as query parameters

### DIFF
--- a/trino/etc/catalog/memory.properties
+++ b/trino/etc/catalog/memory.properties
@@ -1,0 +1,1 @@
+connector.name=memory

--- a/trino/serial.go
+++ b/trino/serial.go
@@ -99,7 +99,7 @@ func Timestamp(year int,
 func Serial(v interface{}) (string, error) {
 	switch x := v.(type) {
 	case nil:
-		return "", UnsupportedArgError{"<nil>"}
+		return "NULL", nil
 
 	// numbers convertible to int
 	case int8:

--- a/trino/serial_test.go
+++ b/trino/serial_test.go
@@ -161,9 +161,9 @@ func TestSerial(t *testing.T) {
 			expectedSerial: "TIMESTAMP '2017-07-10 11:34:25.000123456 Z'",
 		},
 		{
-			name:          "nil",
-			value:         nil,
-			expectedError: true,
+			name:           "nil",
+			value:          nil,
+			expectedSerial: "NULL",
 		},
 		{
 			name:          "slice typed nil",

--- a/trino/trino.go
+++ b/trino/trino.go
@@ -656,6 +656,8 @@ func (st *driverStmt) ExecContext(ctx context.Context, args []driver.NamedValue)
 
 func (st *driverStmt) CheckNamedValue(arg *driver.NamedValue) error {
 	switch arg.Value.(type) {
+	case nil:
+		return nil
 	case Numeric, trinoDate, trinoTime, trinoTimeTz, trinoTimestamp:
 		return nil
 	default:


### PR DESCRIPTION
Fixes #84, fixes #32, but not #34 because the memory connector doesn't support UPDATE and DELETE queries and I didn't want to start another container.