### PR TITLE
Include error code and name on error message

### DIFF
--- a/trino/trino.go
+++ b/trino/trino.go
@@ -725,7 +725,7 @@ type stmtErrorFailureInfo struct {
 }
 
 func (e stmtError) Error() string {
-	return e.FailureInfo.Type + ": " + e.Message
+	return fmt.Sprintf("%v (name: %s, code: %d): %s", e.FailureInfo.Type, e.ErrorName, e.ErrorCode, e.Message)
 }
 
 type stmtStage struct {


### PR DESCRIPTION
Ideally we'd expose the error info in a structured way like suggested in https://github.com/trinodb/trino-go-client/issues/97 . Since that's more involved as requires changing exported interfaces, in the meantime having the info in the error message might be already helpful for telemetry.