### PR TITLE
support Geometry and Geography values as WKT strings

### DIFF
--- a/trino/trino.go
+++ b/trino/trino.go
@@ -1469,7 +1469,7 @@ func (c *typeConverter) ConvertValue(v interface{}) (driver.Value, error) {
 			return nil, err
 		}
 		return vv.Bool, err
-	case "json", "char", "varchar", "varbinary", "interval year to month", "interval day to second", "decimal", "ipaddress", "uuid", "unknown":
+	case "json", "char", "varchar", "varbinary", "interval year to month", "interval day to second", "decimal", "ipaddress", "uuid", "SphericalGeography", "unknown":
 		vv, err := scanNullString(v)
 		if !vv.Valid {
 			return nil, err

--- a/trino/trino.go
+++ b/trino/trino.go
@@ -1469,7 +1469,7 @@ func (c *typeConverter) ConvertValue(v interface{}) (driver.Value, error) {
 			return nil, err
 		}
 		return vv.Bool, err
-	case "json", "char", "varchar", "varbinary", "interval year to month", "interval day to second", "decimal", "ipaddress", "uuid", "SphericalGeography", "unknown":
+	case "json", "char", "varchar", "varbinary", "interval year to month", "interval day to second", "decimal", "ipaddress", "uuid", "Geometry", "SphericalGeography", "unknown":
 		vv, err := scanNullString(v)
 		if !vv.Valid {
 			return nil, err

--- a/trino/trino_test.go
+++ b/trino/trino_test.go
@@ -1419,6 +1419,12 @@ func TestTypeConversion(t *testing.T) {
 				[]interface{}{"b"},
 			},
 		},
+		{
+			DataType:                   "SphericalGeography",
+			RawType:                    "SphericalGeography",
+			ResponseUnmarshalledSample: "Point (0 0)",
+			ExpectedGoValue:            "Point (0 0)",
+		},
 	}
 
 	for _, tc := range testcases {

--- a/trino/trino_test.go
+++ b/trino/trino_test.go
@@ -1420,6 +1420,13 @@ func TestTypeConversion(t *testing.T) {
 			},
 		},
 		{
+			DataType:                   "Geometry",
+			RawType:                    "Geometry",
+			ResponseUnmarshalledSample: "Point (0 0)",
+			ExpectedGoValue:            "Point (0 0)",
+		},
+
+		{
 			DataType:                   "SphericalGeography",
 			RawType:                    "SphericalGeography",
 			ResponseUnmarshalledSample: "Point (0 0)",


### PR DESCRIPTION
Allows us to use the WKT strings returned from Geometry and SphericalGeography expressions in queries like `select st_point(0, 0)` and `select to_spherical_geography(st_point(0, 0))` (both giving `"Point (0 0)"`). This would previously result in a `type not supported: "SphericalGeography"` error.