### PR TITLE
Use latest Go for releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,10 @@
 name: ci
 
 on:
-  - push
-  - pull_request
+  push:
+    branches:
+      - master
+  pull_request:
 
 jobs:
   build:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.20"
+          go-version: "1.22"
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v5


### PR DESCRIPTION
#96 bumped the minimum required version to 1.21, so running releases with 1.20 will likely fail.

Also run the CI workflow only on pushes to the master branch. Now when working on PRs from forks, it runs both in the target repo and in the fork, which is unnecessary.