### PR TITLE
Escape values of extra credentials and session properties

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,17 @@
+changelog:
+  exclude:
+    labels:
+      - ignore-for-release
+  categories:
+    - title: Breaking changes
+      labels:
+        - breaking-change
+    - title: Features
+      labels:
+        - enhancement
+    - title: Bug fixes
+      labels:
+        - bug
+    - title: Other changes
+      labels:
+        - "*"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,2 +1,4 @@
 builds:
 - skip: true
+changelog:
+  use: github-native

--- a/trino/integration_test.go
+++ b/trino/integration_test.go
@@ -497,7 +497,7 @@ handleErr:
 
 func TestIntegrationSessionProperties(t *testing.T) {
 	dsn := *integrationServerFlag
-	dsn += "?session_properties=query_max_run_time=10m,query_priority=2"
+	dsn += "?session_properties=query_max_run_time%3A10m%3Bquery_priority%3A2"
 	db := integrationOpen(t, dsn)
 	defer db.Close()
 	rows, err := db.Query("SHOW SESSION")


### PR DESCRIPTION
Correctly escape values of extra credentials and session properties when
building HTTP headers.
    
Change the format of extra credentials and session properties in the URL
to match the Trino JDBC and Python drivers - keys and values are
separated with a colon (`:`) and multiple entries are separated with a
semicolon (`;`). Note: all special characters, including the semicolon,
must be URL escaped.

Fixes #125