### PR TITLE
Support EXECUTE IMMEDIATE

### DIFF
--- a/trino/etc/config.properties
+++ b/trino/etc/config.properties
@@ -12,3 +12,5 @@ http-server.https.port=8443
 http-server.authentication.allow-insecure-over-http=true
 http-server.https.keystore.path=/etc/trino/secrets/certificate_with_key.pem
 internal-communication.shared-secret=gotrino
+
+query.max-length=5000043

--- a/trino/etc/jvm.config
+++ b/trino/etc/jvm.config
@@ -1,4 +1,4 @@
--Xmx1G
+-Xmx4G
 -XX:+UseG1GC
 -XX:G1HeapRegionSize=32M
 -XX:+UseGCOverheadLimit


### PR DESCRIPTION
Use EXECUTE IMMEDIATE sent in the HTTP request body, instead of putting the query text in HTTP headers. This should allow sending large query text. It can be enabled by setting the `explicitPrepare` option to false in the connection string.

Fixes #123 and fixes #118