### PR TITLE
Add retries for 502, 504 HTTP statuses

### DIFF
--- a/trino/trino.go
+++ b/trino/trino.go
@@ -617,7 +617,7 @@ func (c *Conn) roundTrip(ctx context.Context, req *http.Request) (*http.Response
 					}
 				}
 				return resp, nil
-			case http.StatusServiceUnavailable:
+			case http.StatusBadGateway, http.StatusServiceUnavailable, http.StatusGatewayTimeout:
 				resp.Body.Close()
 				timer.Reset(delay)
 				delay = time.Duration(math.Min(


### PR DESCRIPTION
Add 502 Bad Gateway and 504 Gateway Timeout HTTP status to client's retry logic

Add tests for retries on 502,504 and test that no retry is executed on another status (404)