### PR TITLE
feat: Support `VARBINARY`

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,6 +258,7 @@ types:
 * integers
 * `bool`
 * `string`
+* `[]byte`
 * slices
 * `trino.Numeric` - a string representation of a number
 * `time.Time` - passed to Trino as a timestamp with a time zone
@@ -324,7 +325,11 @@ following types:
 * `json.Number` for any numeric Trino types
 * `[]interface{}` for Trino arrays
 * `map[string]interface{}` for Trino maps
-* `string` for other Trino types, as character, date, time, or timestamp
+* `string` for other Trino types, as character, date, time, or timestamp.
+
+> [!NOTE]
+> `VARBINARY` columns are returned as base64-encoded strings when used within
+> `ROW`, `MAP`, or `ARRAY` values.
 
 ## License
 

--- a/trino/serial.go
+++ b/trino/serial.go
@@ -15,6 +15,7 @@
 package trino
 
 import (
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"math"
@@ -148,9 +149,11 @@ func Serial(v interface{}) (string, error) {
 	case string:
 		return "'" + strings.Replace(x, "'", "''", -1) + "'", nil
 
-		// TODO - []byte should probably be matched to 'VARBINARY' in trino
 	case []byte:
-		return "", UnsupportedArgError{"[]byte"}
+		if x == nil {
+			return "NULL", nil
+		}
+		return "X'" + hex.EncodeToString(x) + "'", nil
 
 	case trinoDate:
 		return fmt.Sprintf("DATE '%04d-%02d-%02d'", x.year, x.month, x.day), nil

--- a/trino/serial_test.go
+++ b/trino/serial_test.go
@@ -47,6 +47,21 @@ func TestSerial(t *testing.T) {
 			expectedSerial: `'hello "world"'`,
 		},
 		{
+			name:           "basic binary",
+			value:          []byte{0x01, 0x02, 0x03},
+			expectedSerial: `X'010203'`,
+		},
+		{
+			name:           "empty binary",
+			value:          []byte{},
+			expectedSerial: `X''`,
+		},
+		{
+			name:           "nil binary",
+			value:          []byte(nil),
+			expectedSerial: `NULL`,
+		},
+		{
 			name:           "int8",
 			value:          int8(100),
 			expectedSerial: "100",

--- a/trino/trino_test.go
+++ b/trino/trino_test.go
@@ -764,7 +764,7 @@ func TestQueryColumns(t *testing.T) {
 			0,
 			false,
 			0,
-			reflect.TypeOf(sql.NullString{}),
+			reflect.TypeOf([]byte{}),
 		},
 		{
 			"JSON",


### PR DESCRIPTION
# Overview
This PR adds support for encoding/decoding the `[]byte` go type as `VARBINARY` data.

# Additional Information
To keep the scope of this PR small, I did _not_ add support for reading `VARBINARY` values within complex types. This is not a regression, but a gap in the serialization/deserialization code. Timestamps, Numbers, etc also have the same issue - they are read into go types right off of the decoded JSON. This means that a `ROW(X'68656C6C6F')` is deserialized as a `[]interface{}{"aGVsbG8="}`. I did update the README to document this behavior.

To showcase this behavior, I've added a (skipped) failing test case. Given the behavior is documented, changing it would be a breaking change. Perhaps an option could be added in the future to recursively parse complex types such that this test case passes?

I'm happy to drop the commit with the skipped test case if we feel it adds noise or does not represent the desired state.

Resolves:
- https://github.com/trinodb/trino-go-client/issues/60

---

> [!NOTE]
> I have signed and emailed an individual CLA.