### PR TITLE
Fix unnecessary cancel requests

### DIFF
--- a/trino/trino.go
+++ b/trino/trino.go
@@ -1140,12 +1140,13 @@ func (qr *driverRows) Close() error {
 	}
 
 	qr.err = io.EOF
-	hs := make(http.Header)
-	if qr.stmt.user != "" {
-		hs.Add(trinoUserHeader, qr.stmt.user)
-	}
 
 	if qr.nextURI != "" {
+		hs := make(http.Header)
+		if qr.stmt.user != "" {
+			hs.Add(trinoUserHeader, qr.stmt.user)
+		}
+
 		ctx, cancel := context.WithTimeout(context.WithoutCancel(qr.ctx), DefaultCancelQueryTimeout)
 		defer cancel()
 		req, err := qr.stmt.conn.newRequest(ctx, "DELETE", qr.nextURI, nil, hs)
@@ -1164,6 +1165,7 @@ func (qr *driverRows) Close() error {
 		resp.Body.Close()
 
 	}
+
 	return qr.err
 }
 
@@ -1219,11 +1221,6 @@ func (qr *driverRows) Next(dest []driver.Value) error {
 		if err := qr.fetch(); err != nil {
 			qr.err = err
 			return err
-		}
-
-		if len(qr.data) == 0 {
-			qr.err = io.EOF
-			return qr.err
 		}
 	}
 


### PR DESCRIPTION
# Overview
This PR fixes unnecessary delete requests when the query is already finished.
# Explanation
This change addresses Issue #102 
- When using `QueryRow` followed by a `Scan`, the Trino driver first calls the `Next` method and then the Close method. The `Close` method triggers a delete request to cancel the query, even when the query has already completed.
- My initial approach was to use `nextUri` in the `Close` method instead of directly calling `/v1/query/queryId`, as suggested in the documentation and implemented by other drivers. However, to make this work, I needed to always update `rows.nextUri` inside the `fetch` method, as it was previously retaining only the first URI set [here](https://github.com/Flgado/trino-go-client/blob/bc0714dc52af6f669b36b07f08f1af71e1287c2a/trino/trino.go#L891-L898). Despite these changes, the issue persisted.
- To resolve this, I modified the `Next` method so that when all rows have been read, it fetches the next set of rows. This works because our `fetch` method, along with the running Goroutines, follows `nextUri` until data is retrieved.
  -  For `QueryRow`, this ensures that when the query reaches the finished state with no more data, nextUri is cleared, preventing an unnecessary request on Close().
  -  For `QueryContext`, this is also fine because it fetches the next batch of data, ensuring that additional data (if available) is retrieved correctly.