### PR TITLE
Ensure Query Cancellation on Context Deadline Expiry 

### DIFF
--- a/trino/trino.go
+++ b/trino/trino.go
@@ -1342,7 +1342,7 @@ func (qr *driverRows) fetch() error {
 				// Channel was closed, which means the statement
 				// or rows were closed.
 				err = io.EOF
-			} else if err == context.Canceled {
+			} else if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 				qr.Close()
 			}
 			qr.err = err


### PR DESCRIPTION
## Problem description
- When the driver is used with a context deadline, and the deadline is reached before processing all data, the driver does not cancel the underlying Trino query. This happens because the expiration of the context deadline isn't properly handled, and the driver does not trigger the necessary steps to cancel the query.

## Solution
This pull request addresses the issue by ensuring that the Close method is called when the context deadline is reached. This method will initiate a delete request, notifying Trino to cancel the corresponding underlying query. By adding this behavior, the query will be properly canceled when the context deadline expires, preventing unnecessary resource usage and improving the overall reliability of the system.