### PR TITLE
Do not require headers on spooled segments

### DIFF
--- a/trino/trino.go
+++ b/trino/trino.go
@@ -1348,9 +1348,13 @@ func (sp *spoolingProtocol) fetch() ([]queryData, error) {
 			if !ok || ackUri == "" {
 				return nil, fmt.Errorf("missing or invalid 'ackUri' field in spooled segment at index %d", segmentIndex)
 			}
-			headers, ok := segment["headers"].(map[string]interface{})
-			if !ok {
-				return nil, fmt.Errorf("missing or invalid 'headers' field in spooled segment at index %d", segmentIndex)
+
+			headers := make(map[string]interface{})
+			if rawHeaders, exists := segment["headers"]; exists {
+				headers, ok = rawHeaders.(map[string]interface{})
+				if !ok {
+					return nil, fmt.Errorf("invalid 'headers' field in spooled segment at index %d: expected map[string]interface{}", segmentIndex)
+				}
 			}
 
 			data, err := sp.fetchSegment(uri, ackUri, headers)

--- a/trino/trino_test.go
+++ b/trino/trino_test.go
@@ -1202,6 +1202,19 @@ func TestSpoolingProtocolSpooledSegmentDecoders(t *testing.T) {
 			DownloadedData: mustDecodeBase64("KLUv/QQAgQAAW1sxMDAwXSxbMTAwMDFdXZfUttw="),
 		},
 		{
+			Name: "spooledSegmentWithoutHeadersOnReponse", // headers are optional
+			Segments: []map[string]interface{}{
+				{
+					"type":     "spooled",
+					"metadata": map[string]interface{}{"uncompressedSize": 16, "rowOffset": 2, "segmentSize": 29},
+					"ackUri":   "test",
+				},
+			},
+			Encoding:       "json+zstd",
+			ExpectedResult: []int{1000, 10001},
+			DownloadedData: mustDecodeBase64("KLUv/QQAgQAAW1sxMDAwXSxbMTAwMDFdXZfUttw="),
+		},
+		{
 			Name: "zlibCompression",
 			Segments: []map[string]interface{}{
 				{
@@ -1565,7 +1578,7 @@ func TestSpoolingProtocolSpooledSegmentErrorHandling(t *testing.T) {
 			expectedError: "missing or invalid 'ackUri' field in spooled segment at index 0",
 		},
 		{
-			name: "MissingHeaders",
+			name: "wrongHeadersFormat",
 			segments: []map[string]interface{}{
 				{
 					"type":   "spooled",
@@ -1577,9 +1590,13 @@ func TestSpoolingProtocolSpooledSegmentErrorHandling(t *testing.T) {
 						"uncompressedSize": 2,
 						"rowOffset":        0,
 					},
+					"headers": [][]string{
+						{"x-amz-server-side-encryption-customer-algorithm", "AES256"},
+						{"x-amz-server-side-encryption-customer-key", "key"},
+					},
 				},
 			},
-			expectedError: "missing or invalid 'headers' field in spooled segment at index 0",
+			expectedError: "invalid 'headers' field in spooled segment at index 0: expected map[string]interface{}",
 		},
 		{
 			name: "HeadersWithMultipleValues",


### PR DESCRIPTION
Fix issue [147](https://github.com/trinodb/trino-go-client/issues/147).
- Headers are not mandatory on spooled segments