### PR TITLE
Add Client Tags Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,6 +259,36 @@ Default:        "true"
 
 The `explicitPrepare` parameter controls how queries are sent to the Trino server. When set to `false`, the client uses `EXECUTE IMMEDIATE` which sends the query text in the HTTP request body instead of HTTP headers. This allows sending large query text that would otherwise exceed HTTP header size limits. When set to `true` (default), queries use explicit prepared statements sent via HTTP headers.
 
+##### `clientTags`
+
+```
+Type:           string
+Valid values:   comma-separated list of tags (e.g. tag1,tag2)
+Default:        empty
+```
+
+The `clientTags` parameter is optional and is used to identify Trino resource groups. 
+This helps with query tracking and resource management in Trino clusters.
+
+**DSN parameter example:**
+```
+clientTags=tag1,tag2
+```
+
+**Config struct example:**
+```go
+config := &Config{
+    ServerURI:  "http://foobar@localhost:8080",
+    ClientTags: []string{"tag1", "tag2", "tag3"},
+}
+
+dsn, err := config.FormatDSN()
+```
+
+**Query parameter example (overrides DSN client tags):**
+```go
+rows, err := db.Query(query, sql.Named("X-Trino-Client-Tags", "tag1,tag2,tag3"))
+```
 #### Examples
 
 ```


### PR DESCRIPTION
# Description

This PR adds support for the `X-Trino-Client-Tags` header to be pass as connection url.
The `X-Trino-Client-Tags` header is part of the official Trino client protocol and allows sending a comma-separated list of tags. These tags can be used for resource management, query monitoring, and routing rules.
This Pr also add integration tests to `X-Trino-Client-Tags` header when is passed as NamedArg

# Testing

Integration tests ensure that Trino correctly receives the tags by checking the query status and validating that the tags sent are the ones set for that query session.

# Motivation

This feature was requested by the community in issue #121 and is also needed by [grafana-trino#309](https://github.com/trinodb/grafana-trino/pull/309) that depends on trino go client (so is good to have integration tests making sure is working properly .
