### PR TITLE
Don't cancel finished queries

### DIFF
--- a/trino/trino.go
+++ b/trino/trino.go
@@ -1515,6 +1515,9 @@ func (qr *driverRows) Close() error {
 		return nil
 	}
 	qr.err = io.EOF
+	if !qr.stmt.usingSpooledProtocol && qr.nextURI == "" {
+		return qr.err
+	}
 	hs := make(http.Header)
 	if qr.stmt.user != "" {
 		hs.Add(trinoUserHeader, qr.stmt.user)
@@ -1973,6 +1976,7 @@ func (qr *driverRows) fetch() error {
 			}
 
 			qr.rowindex = 0
+			qr.nextURI = qresp.NextURI
 			switch data := qresp.Data.(type) {
 			case []interface{}:
 				// direct protocol


### PR DESCRIPTION
When closing query rows, if the current segment is the last one (there's no next URI), don't cancel the query. This does not apply to spooled segments.

Fixes #102

Supersedes #152