### PR TITLE
Add spooling query heartbeat

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,6 +249,16 @@ Default:        nil
 
 The `query_timeout` parameter sets a timeout for the query. If the query takes longer than the timeout, it will be cancelled. If it is not set the default context timeout will be used.
 
+##### `heartbeat_interval`
+
+```
+Type:           time.Duration
+Valid values:   positive duration string (e.g. 30s, 1m)
+Default:        unset (client uses 30s between spooling heartbeats)
+```
+
+The `heartbeat_interval` parameter sets how often the client sends a **HEAD** heartbeat to the current `nextUri` while a **spooled** query is in progress. It applies to the whole connection (same idea as session-scoped client settings in other Trino clients). Only used when the server uses the spooling protocol.
+
 ##### `explicitPrepare`
 
 ```
@@ -425,6 +435,8 @@ following types:
 The client supports the [Trino spooling protocol](https://trino.io/docs/current/client/client-protocol.html#spooling-protocol), which enables efficient retrieval of large result sets by downloading data in segments, optionally in parallel and out-of-order.
 
 If the Trino server has the spooling protocol enabled, the client will use it by default with the `json` encoding.
+
+While a spooled query is in progress, the client sends periodic **HEAD** requests to the current `nextUri` (same URL used for result pages) so the coordinator treats the client as still active, which helps avoid query abandonment when result consumption is slow. The server must support this endpoint (Trino 475+).
 
 You can configure other encodings:
 

--- a/trino/integration_test.go
+++ b/trino/integration_test.go
@@ -308,7 +308,7 @@ func setupLocalStack(pool *dt.Pool, networkID string) (*dt.Resource, error) {
 	localstackResource, err := pool.RunWithOptions(&dt.RunOptions{
 		Name:       DockerLocalStackName,
 		Repository: "localstack/localstack",
-		Tag:        "latest",
+		Tag:        "4.14.0",
 		Env: []string{
 			"SERVICES=s3",
 			"region_name=us-east-1",

--- a/trino/trino.go
+++ b/trino/trino.go
@@ -167,6 +167,9 @@ const (
 	defaulttrinoEncoding           = "json"
 	defaultSourceName              = "trino-go-client"
 	defaultKerberosServiceName     = "trino"
+	maxHeartbeatFailures           = 3
+	heartbeatRequestTimeout        = 10 * time.Second
+	defaultHeartbeatInterval       = 30 * time.Second
 )
 
 var (
@@ -210,6 +213,7 @@ type Config struct {
 	DisableExplicitPrepare     bool              // Disable the use of explicit prepared statements (optional, default is false)
 	ForwardAuthorizationHeader bool              // Allow forwarding the `accessToken` named query parameter in the authorization header, overwriting the `AccessToken` option, if set (optional)
 	QueryTimeout               *time.Duration    // Configurable timeout for query (optional)
+	HeartbeatInterval          *time.Duration    // Interval between spooling-protocol HEAD heartbeats (optional; DSN: heartbeat_interval)
 	Roles                      map[string]string // Roles (optional)
 }
 
@@ -298,6 +302,17 @@ func ParseDSN(dsn string) (*Config, error) {
 			return nil, fmt.Errorf("trino: invalid timeout for query_timeout: %q", queryTimeoutStr)
 		}
 		config.QueryTimeout = &queryTimeout
+	}
+
+	if heartbeatStr := query.Get("heartbeat_interval"); heartbeatStr != "" {
+		heartbeat, err := time.ParseDuration(heartbeatStr)
+		if err != nil {
+			return nil, fmt.Errorf("trino: invalid duration for heartbeat_interval: %q", heartbeatStr)
+		}
+		if heartbeat <= 0 {
+			return nil, fmt.Errorf("trino: heartbeat_interval must be positive, got %s", heartbeatStr)
+		}
+		config.HeartbeatInterval = &heartbeat
 	}
 
 	if kerberosParam := query.Get(kerberosEnabledConfig); kerberosParam != "" {
@@ -438,6 +453,10 @@ func (c *Config) FormatDSN() (string, error) {
 		query.Add("query_timeout", c.QueryTimeout.String())
 	}
 
+	if c.HeartbeatInterval != nil {
+		query.Add("heartbeat_interval", c.HeartbeatInterval.String())
+	}
+
 	for k, v := range map[string]string{
 		"catalog":            c.Catalog,
 		"clientTags":         strings.Join(c.ClientTags, commaSeparator),
@@ -470,6 +489,7 @@ type Conn struct {
 	useExplicitPrepare         bool
 	forwardAuthorizationHeader bool
 	queryTimeout               *time.Duration
+	heartbeatInterval          *time.Duration
 }
 
 var (
@@ -583,6 +603,7 @@ func newConn(dsn string) (*Conn, error) {
 		useExplicitPrepare:         !conf.DisableExplicitPrepare,
 		forwardAuthorizationHeader: conf.ForwardAuthorizationHeader,
 		queryTimeout:               conf.QueryTimeout,
+		heartbeatInterval:          conf.HeartbeatInterval,
 	}
 
 	var user string
@@ -904,6 +925,9 @@ type driverStmt struct {
 	errors                        chan error
 	doneCh                        chan struct{}
 	segmentDispatcherDoneCh       chan struct{}
+	heartbeatInterval             time.Duration
+	heartbeatNextURICh            chan string
+	waitHeartbeat                 sync.WaitGroup
 }
 
 type segmentToDecode struct {
@@ -983,6 +1007,11 @@ func (st *driverStmt) Close() error {
 
 	st.waitSegmentDecodersWorkers.Wait()
 
+	st.waitHeartbeat.Wait()
+	if st.heartbeatNextURICh != nil {
+		close(st.heartbeatNextURICh)
+	}
+
 	close(st.nextURIs)
 	close(st.errors)
 
@@ -994,6 +1023,7 @@ func (st *driverStmt) Close() error {
 	st.segmentsToProccess = nil
 	st.decodedSegments = nil
 	st.spoolingRowsChannel = nil
+	st.heartbeatNextURICh = nil
 
 	return nil
 }
@@ -2081,6 +2111,7 @@ func (qr *driverRows) fetch() error {
 			case map[string]interface{}:
 				// spooling protocol
 				qr.stmt.startSpoolingProtocolWorkers(qr.ctx)
+				qr.stmt.sendHeartbeatURI(qresp.NextURI)
 				qr.startOrderedSegmentStreamer()
 
 				err := qr.queueSpoolingSegments(data)
@@ -2120,6 +2151,12 @@ func (st *driverStmt) startSpoolingProtocolWorkers(ctx context.Context) {
 		st.spoolingMaxOutOfOrderSegments = defaultallowedOutOfOrder
 	}
 
+	if st.conn.heartbeatInterval != nil {
+		st.heartbeatInterval = *st.conn.heartbeatInterval
+	} else {
+		st.heartbeatInterval = defaultHeartbeatInterval
+	}
+
 	downloadSegmentsCtx, cancelDownloadWorkers := context.WithCancel(context.WithoutCancel(ctx))
 	st.cancelDownloadWorkers = cancelDownloadWorkers
 	decodeSegmentCtx, cancelDecodersWorkers := context.WithCancel(context.WithoutCancel(ctx))
@@ -2134,9 +2171,93 @@ func (st *driverStmt) startSpoolingProtocolWorkers(ctx context.Context) {
 	st.segmentThrottleCh = make(chan struct{}, st.spoolingMaxOutOfOrderSegments)
 	st.decodedSegments = make(chan decodedSegment)
 
+	st.heartbeatNextURICh = make(chan string, 1)
+
 	st.startSegmentDispatcher()
 	st.startDownloadSegmentsWorkers(downloadSegmentsCtx)
 	st.startSegmentsDecodersWorkers(decodeSegmentCtx)
+	st.startHeartbeat(ctx)
+}
+
+func (st *driverStmt) sendHeartbeatURI(uri string) {
+	if uri == "" {
+		return
+	}
+	// Non-blocking: drain any old value, then send the new one.
+	select {
+	case <-st.heartbeatNextURICh:
+	default:
+	}
+	select {
+	case st.heartbeatNextURICh <- uri:
+	default:
+	}
+}
+
+func (st *driverStmt) startHeartbeat(ctx context.Context) {
+	ticker := time.NewTicker(st.heartbeatInterval)
+	st.waitHeartbeat.Add(1)
+
+	go func() {
+		defer st.waitHeartbeat.Done()
+		defer ticker.Stop()
+		var currentNextURI string
+		var consecutiveFailures int
+
+		for {
+			select {
+			case uri, ok := <-st.heartbeatNextURICh:
+				if !ok {
+					return
+				}
+				currentNextURI = uri
+
+			case <-ticker.C:
+				if currentNextURI == "" {
+					continue
+				}
+
+				reqCtx, cancel := context.WithTimeout(ctx, heartbeatRequestTimeout)
+				hs := make(http.Header)
+				hs.Add(trinoUserHeader, st.user)
+				req, err := st.conn.newRequest(reqCtx, "HEAD", currentNextURI, nil, hs)
+				if err != nil {
+					cancel()
+					consecutiveFailures++
+					if consecutiveFailures >= maxHeartbeatFailures {
+						return
+					}
+					continue
+				}
+
+				resp, err := st.conn.httpClient.Do(req)
+				cancel()
+				if err != nil {
+					consecutiveFailures++
+					if consecutiveFailures >= maxHeartbeatFailures {
+						return
+					}
+					continue
+				}
+				resp.Body.Close()
+
+				switch resp.StatusCode {
+				case http.StatusOK:
+					consecutiveFailures = 0
+				case http.StatusNotFound, http.StatusMethodNotAllowed:
+					return
+				default:
+					consecutiveFailures++
+					if consecutiveFailures >= maxHeartbeatFailures {
+						return
+					}
+				}
+
+			case <-st.doneCh:
+				return
+			}
+		}
+	}()
 }
 
 func (st *driverStmt) startSegmentDispatcher() {
@@ -2305,6 +2426,7 @@ func (qr *driverRows) proccessSpollingSegments() {
 					return
 				}
 
+				qr.stmt.sendHeartbeatURI(qresp.NextURI)
 				err = qr.initColumns(&qresp)
 				if err != nil {
 					qr.stmt.errors <- err

--- a/trino/trino_test.go
+++ b/trino/trino_test.go
@@ -28,6 +28,7 @@ import (
 	"reflect"
 	"runtime/debug"
 	"sort"
+	"sync"
 	"testing"
 	"time"
 
@@ -83,6 +84,7 @@ func TestParseDSNToConfig(t *testing.T) {
 				DisableExplicitPrepare:     true,
 				ForwardAuthorizationHeader: true,
 				QueryTimeout:               &[]time.Duration{5 * time.Minute}[0],
+				HeartbeatInterval:          &[]time.Duration{2 * time.Minute}[0],
 				Roles:                      map[string]string{"catalog1": "role1", "catalog2": "role2"},
 			},
 		},
@@ -107,6 +109,7 @@ func TestParseDSNToConfig(t *testing.T) {
 				DisableExplicitPrepare:     true,
 				ForwardAuthorizationHeader: true,
 				QueryTimeout:               &[]time.Duration{5 * time.Minute}[0],
+				HeartbeatInterval:          &[]time.Duration{2 * time.Minute}[0],
 			},
 		},
 		{
@@ -160,6 +163,7 @@ func TestParseDSNToConfigAllFieldsHandled(t *testing.T) {
 		"explicitPrepare=false&" +
 		"forwardAuthorizationHeader=true&" +
 		"query_timeout=5m30s&" +
+		"heartbeat_interval=45s&" +
 		"roles=catalog1%3Arole1%3Bcatalog2%3Arole2"
 
 	config, err := ParseDSN(complexDSN)
@@ -209,6 +213,8 @@ func TestParseDSNToConfigAllFieldsHandled(t *testing.T) {
 	assert.Equal(t, true, config.ForwardAuthorizationHeader)
 	assert.NotNil(t, config.QueryTimeout)
 	assert.Equal(t, 5*time.Minute+30*time.Second, *config.QueryTimeout)
+	assert.NotNil(t, config.HeartbeatInterval)
+	assert.Equal(t, 45*time.Second, *config.HeartbeatInterval)
 	assert.Equal(t, map[string]string{"catalog1": "role1", "catalog2": "role2"}, config.Roles)
 }
 
@@ -526,6 +532,58 @@ func TestQueryTimeout(t *testing.T) {
 
 	want := "https://foobar@localhost:8090?query_timeout=10s&source=trino-go-client"
 	assert.Equal(t, want, dsn)
+}
+
+func TestHeartbeatIntervalDSNParse(t *testing.T) {
+	base := "http://user@127.0.0.1:9"
+
+	for _, tc := range []struct {
+		name    string
+		query   string
+		wantErr string
+	}{
+		{name: "invalid duration", query: "heartbeat_interval=not_a_duration", wantErr: "invalid duration for heartbeat_interval"},
+		{name: "zero", query: "heartbeat_interval=0s", wantErr: "heartbeat_interval must be positive"},
+		{name: "negative", query: "heartbeat_interval=-30s", wantErr: "heartbeat_interval must be positive"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := ParseDSN(base + "/?" + tc.query)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tc.wantErr)
+		})
+	}
+
+	t.Run("valid", func(t *testing.T) {
+		cfg, err := ParseDSN(base + "/?heartbeat_interval=750ms")
+		require.NoError(t, err)
+		require.NotNil(t, cfg.HeartbeatInterval)
+		assert.Equal(t, 750*time.Millisecond, *cfg.HeartbeatInterval)
+	})
+}
+
+func TestHeartbeatIntervalFormatDSNRoundTrip(t *testing.T) {
+	hb := 90 * time.Second
+	c := &Config{
+		ServerURI:         "http://user@localhost:8080",
+		HeartbeatInterval: &hb,
+	}
+	dsn, err := c.FormatDSN()
+	require.NoError(t, err)
+
+	got, err := ParseDSN(dsn)
+	require.NoError(t, err)
+	require.NotNil(t, got.HeartbeatInterval)
+	assert.Equal(t, 90*time.Second, *got.HeartbeatInterval)
+}
+
+func TestHeartbeatIntervalPingRejectsInvalidDSN(t *testing.T) {
+	db, err := sql.Open("trino", "http://user@127.0.0.1:9/?heartbeat_interval=0s")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	err = db.Ping()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "heartbeat_interval must be positive")
 }
 
 func TestRoundTripRetryQueryError(t *testing.T) {
@@ -2604,6 +2662,259 @@ func TestSpoolingProtocolInlineSegmentErrorHandling(t *testing.T) {
 			require.Contains(t, err.Error(), tc.expectedError)
 		})
 	}
+}
+
+func newSpooledSegmentServer(t *testing.T, headHandler func(w http.ResponseWriter, r *http.Request), downloadDelay time.Duration) *httptest.Server {
+	t.Helper()
+	var ts *httptest.Server
+	ts = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "HEAD" {
+			if headHandler != nil {
+				headHandler(w, r)
+			} else {
+				w.WriteHeader(http.StatusOK)
+			}
+			return
+		}
+		switch r.URL.Path {
+		case "/v1/statement":
+			json.NewEncoder(w).Encode(&stmtResponse{
+				ID:      "fake-query",
+				NextURI: ts.URL + "/v1/statement/20210817_140827_00000_arvdv/1",
+			})
+		case "/v1/statement/20210817_140827_00000_arvdv/1":
+			json.NewEncoder(w).Encode(&queryResponse{
+				ID:      "fake-query",
+				NextURI: ts.URL + "/v1/statement/20210817_140827_00000_arvdv/2",
+				Columns: []queryColumn{
+					{
+						Name: "_col0",
+						Type: "integer",
+						TypeSignature: typeSignature{
+							RawType:   "integer",
+							Arguments: []typeArgument{},
+						},
+					},
+				},
+				Data: map[string]interface{}{
+					"encoding": "json",
+					"segments": []map[string]interface{}{
+						{
+							"uri":      ts.URL + "/v1/spooled/download/seg0",
+							"type":     "spooled",
+							"metadata": map[string]interface{}{"segmentSize": 8, "rowOffset": 0, "rowsCount": 1},
+							"ackUri":   ts.URL + "/v1/spooled/ack/seg0",
+							"headers":  map[string]interface{}{},
+						},
+					},
+				},
+			})
+		case "/v1/statement/20210817_140827_00000_arvdv/2":
+			json.NewEncoder(w).Encode(&queryResponse{})
+		case "/v1/spooled/download/seg0":
+			if downloadDelay > 0 {
+				time.Sleep(downloadDelay)
+			}
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte("[[1000]]"))
+		case "/v1/spooled/ack/seg0":
+			w.WriteHeader(http.StatusOK)
+		default:
+			w.WriteHeader(http.StatusInternalServerError)
+			json.NewEncoder(w).Encode(ErrTrino{ErrorName: "Unexpected request"})
+		}
+	}))
+	return ts
+}
+
+func TestHeartbeatSentDuringSpooledDownload(t *testing.T) {
+	var headCount int32
+	var mu sync.Mutex
+
+	ts := newSpooledSegmentServer(t, func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		headCount++
+		mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	}, 3*time.Second)
+	defer ts.Close()
+
+	db, err := sql.Open("trino", ts.URL+"?heartbeat_interval=500ms")
+	require.NoError(t, err)
+	defer db.Close()
+
+	rows, err := db.Query("SELECT 1")
+	require.NoError(t, err)
+	defer rows.Close()
+
+	var results []int
+	for rows.Next() {
+		var value int
+		err := rows.Scan(&value)
+		require.NoError(t, err)
+		results = append(results, value)
+	}
+
+	require.NoError(t, rows.Err())
+	assert.Equal(t, []int{1000}, results)
+
+	mu.Lock()
+	count := headCount
+	mu.Unlock()
+	assert.GreaterOrEqual(t, count, int32(1), "Expected at least one heartbeat HEAD request")
+}
+
+func TestHeartbeatDisabledOn405(t *testing.T) {
+	var headCount int32
+	var mu sync.Mutex
+
+	ts := newSpooledSegmentServer(t, func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		headCount++
+		mu.Unlock()
+		w.WriteHeader(http.StatusMethodNotAllowed)
+	}, 3*time.Second)
+	defer ts.Close()
+
+	db, err := sql.Open("trino", ts.URL+"?heartbeat_interval=500ms")
+	require.NoError(t, err)
+	defer db.Close()
+
+	rows, err := db.Query("SELECT 1")
+	require.NoError(t, err)
+	defer rows.Close()
+
+	var results []int
+	for rows.Next() {
+		var value int
+		err := rows.Scan(&value)
+		require.NoError(t, err)
+		results = append(results, value)
+	}
+
+	require.NoError(t, rows.Err())
+	assert.Equal(t, []int{1000}, results)
+
+	mu.Lock()
+	count := headCount
+	mu.Unlock()
+	assert.Equal(t, int32(1), count, "Expected exactly one heartbeat attempt before disabling")
+}
+
+func TestHeartbeatDisabledOn404(t *testing.T) {
+	var headCount int32
+	var mu sync.Mutex
+
+	ts := newSpooledSegmentServer(t, func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		headCount++
+		mu.Unlock()
+		w.WriteHeader(http.StatusNotFound)
+	}, 3*time.Second)
+	defer ts.Close()
+
+	db, err := sql.Open("trino", ts.URL+"?heartbeat_interval=500ms")
+	require.NoError(t, err)
+	defer db.Close()
+
+	rows, err := db.Query("SELECT 1")
+	require.NoError(t, err)
+	defer rows.Close()
+
+	var results []int
+	for rows.Next() {
+		var value int
+		err := rows.Scan(&value)
+		require.NoError(t, err)
+		results = append(results, value)
+	}
+
+	require.NoError(t, rows.Err())
+	assert.Equal(t, []int{1000}, results)
+
+	mu.Lock()
+	count := headCount
+	mu.Unlock()
+	assert.Equal(t, int32(1), count, "Expected exactly one heartbeat attempt before disabling")
+}
+
+func TestHeartbeatDisabledAfter3Failures(t *testing.T) {
+	var headCount int32
+	var mu sync.Mutex
+
+	ts := newSpooledSegmentServer(t, func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		headCount++
+		mu.Unlock()
+		w.WriteHeader(http.StatusInternalServerError)
+	}, 5*time.Second)
+	defer ts.Close()
+
+	db, err := sql.Open("trino", ts.URL+"?heartbeat_interval=500ms")
+	require.NoError(t, err)
+	defer db.Close()
+
+	rows, err := db.Query("SELECT 1")
+	require.NoError(t, err)
+	defer rows.Close()
+
+	var results []int
+	for rows.Next() {
+		var value int
+		err := rows.Scan(&value)
+		require.NoError(t, err)
+		results = append(results, value)
+	}
+
+	require.NoError(t, rows.Err())
+	assert.Equal(t, []int{1000}, results)
+
+	mu.Lock()
+	count := headCount
+	mu.Unlock()
+	assert.Equal(t, int32(3), count, "Expected exactly 3 heartbeat attempts before disabling")
+}
+
+func TestHeartbeatResetOnSuccess(t *testing.T) {
+	var headCount int32
+	var mu sync.Mutex
+
+	ts := newSpooledSegmentServer(t, func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		current := headCount
+		headCount++
+		mu.Unlock()
+		if current < 2 {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}, 5*time.Second)
+	defer ts.Close()
+
+	db, err := sql.Open("trino", ts.URL+"?heartbeat_interval=500ms")
+	require.NoError(t, err)
+	defer db.Close()
+
+	rows, err := db.Query("SELECT 1")
+	require.NoError(t, err)
+	defer rows.Close()
+
+	var results []int
+	for rows.Next() {
+		var value int
+		err := rows.Scan(&value)
+		require.NoError(t, err)
+		results = append(results, value)
+	}
+
+	require.NoError(t, rows.Err())
+	assert.Equal(t, []int{1000}, results)
+
+	mu.Lock()
+	count := headCount
+	mu.Unlock()
+	assert.GreaterOrEqual(t, count, int32(3), "Expected at least 3 heartbeat attempts (2 failures + 1 success)")
 }
 
 func TestProtocolErrorHandling(t *testing.T) {


### PR DESCRIPTION
- During the `spooling protocol`, send periodic HTTP **HEAD** requests to the current **nextUri** so the coordinator still sees an active client while results are consumed slowly.

- Configure interval on the **connection**: DSN `heartbeat_interval` and Config.HeartbeatInterval (positive time.ParseDuration); if omitted, default 30s when spooling starts.

- Stop heartbeating on **404/405** (unsupported) or after repeated failures; tie lifecycle to statement Close (doneCh + WaitGroup), with a short per-request timeout for HEAD.

- **Tests**: spooled mock server + HEAD counting; DSN validation (invalid / zero / negative / valid); format round-trip; Ping path for bad DSN.

- **Docs**: README spooling section + DSN parameter list.

## Integration tests
I did not add an integration test in the same style as the Java client change in [trinodb/trino#25267](https://github.com/trinodb/trino/pull/25267).

That PR can drive a small `query.client.timeout` on a test-only Trino server so slow spooled consumption reliably hits “query abandoned” unless heartbeats run. Here, our integration suite talks to a normal shared Trino (Docker in CI). `query.client.timeout` is **coordinator-wide**, not something we can set per connection or per query from the Go client, so we cannot cheaply reproduce the same “tight timeout” scenario without extra Trino config / a dedicated container / a new CI profile. Any idea for this @nineinchnick ?

So this PR validates heartbeats with unit tests (mock server, count HEAD to the current nextUri, DSN parsing, etc.), which still checks the client behavior without requiring a special server setup.