### PR TITLE
Error when a DSN password is used over HTTP

### DIFF
--- a/trino/trino.go
+++ b/trino/trino.go
@@ -228,6 +228,9 @@ func ParseDSN(dsn string) (*Config, error) {
 	if err != nil {
 		return nil, fmt.Errorf("invalid DSN: %w", err)
 	}
+	if err := requireTLSForPassword(serverURL); err != nil {
+		return nil, err
+	}
 
 	query := serverURL.Query()
 	config := &Config{}
@@ -340,6 +343,16 @@ func ParseDSN(dsn string) (*Config, error) {
 	return config, nil
 }
 
+func requireTLSForPassword(serverURL *url.URL) error {
+	if serverURL.User == nil {
+		return nil
+	}
+	if pass, _ := serverURL.User.Password(); pass != "" && serverURL.Scheme != "https" {
+		return fmt.Errorf("trino: TLS/SSL is required for authentication with username and password")
+	}
+	return nil
+}
+
 func parseMapParameter(value, paramName, entrySeparator, keyValueSeparator string) (map[string]string, error) {
 	result := make(map[string]string)
 	for _, entry := range strings.Split(value, entrySeparator) {
@@ -357,6 +370,9 @@ func (c *Config) FormatDSN() (string, error) {
 
 	serverURL, err := url.Parse(c.ServerURI)
 	if err != nil {
+		return "", err
+	}
+	if err := requireTLSForPassword(serverURL); err != nil {
 		return "", err
 	}
 	var sessionkv []string

--- a/trino/trino_test.go
+++ b/trino/trino_test.go
@@ -212,6 +212,48 @@ func TestParseDSNToConfigAllFieldsHandled(t *testing.T) {
 	assert.Equal(t, map[string]string{"catalog1": "role1", "catalog2": "role2"}, config.Roles)
 }
 
+func TestParseDSNPasswordRequiresTLS(t *testing.T) {
+	tests := []struct {
+		name    string
+		dsn     string
+		wantErr string
+	}{
+		{
+			name:    "http with password",
+			dsn:     "http://user:secret@localhost:8080",
+			wantErr: "trino: TLS/SSL is required for authentication with username and password",
+		},
+		{
+			name: "http with username only",
+			dsn:  "http://user@localhost:8080",
+		},
+		{
+			name: "https with password",
+			dsn:  "https://user:secret@localhost:8080",
+		},
+		{
+			name: "http with empty password",
+			dsn:  "http://user:@localhost:8080",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := ParseDSN(tt.dsn)
+			if tt.wantErr == "" {
+				require.NoError(t, err)
+				return
+			}
+			assert.EqualError(t, err, tt.wantErr)
+		})
+	}
+}
+
+func TestFormatDSNPasswordRequiresTLS(t *testing.T) {
+	c := &Config{ServerURI: "http://user:secret@localhost:8080"}
+	_, err := c.FormatDSN()
+	assert.EqualError(t, err, "trino: TLS/SSL is required for authentication with username and password")
+}
+
 func TestConfigFormatDSNTags(t *testing.T) {
 	tests := []struct {
 		name   string
@@ -488,6 +530,7 @@ func TestConnErrorDSN(t *testing.T) {
 	}{
 		{Name: "malformed", DSN: "://"},
 		{Name: "unknown_client", DSN: "http://localhost?custom_client=unknown"},
+		{Name: "http_password", DSN: "http://user:secret@localhost:8080"},
 	}
 
 	for _, tc := range testcases {


### PR DESCRIPTION
close #205 

Reject username/password in an `http` DSN instead of dropping the password silently. TLS is required, same as the Java client.

Ps: Integration tests will fail until we will merge one of the PR's with the pinned localstack