### PR TITLE
Reject the accessToken named argument when forwarding is disabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,10 @@ This driver supports forwarding authorization headers by adding a [NamedArg](htt
 
 When enabled, this configuration will override the `AccessToken` set in the `Config` struct.
 
+Using the `accessToken` named argument without enabling `ForwardAuthorizationHeader` returns an
+error, so the token is never sent as part of the query text, where Trino would persist it in the
+query history.
+
 
 #### System access control and per-query user information
 

--- a/trino/trino.go
+++ b/trino/trino.go
@@ -109,6 +109,10 @@ var (
 
 	// ErrInvalidProgressCallbackHeader indicates that server did not get valid headers for progress callback
 	ErrInvalidProgressCallbackHeader = errors.New("trino: both " + trinoProgressCallbackParam + " and " + trinoProgressCallbackPeriodParam + " must be set when using progress callback")
+
+	// ErrForwardAuthorizationHeaderNotEnabled indicates that the accessToken named argument was used
+	// without enabling forwarding, which would otherwise send the token as part of the query text.
+	ErrForwardAuthorizationHeaderNotEnabled = errors.New("trino: " + accessTokenConfig + " named argument requires " + forwardAuthorizationHeaderConfig + " to be enabled")
 )
 
 const (
@@ -1212,8 +1216,14 @@ func (st *driverStmt) exec(ctx context.Context, args []driver.NamedValue) (*stmt
 				continue
 			}
 
-			if st.conn.forwardAuthorizationHeader && arg.Name == accessTokenConfig {
-				token := arg.Value.(string)
+			if arg.Name == accessTokenConfig {
+				if !st.conn.forwardAuthorizationHeader {
+					return nil, ErrForwardAuthorizationHeaderNotEnabled
+				}
+				token, ok := arg.Value.(string)
+				if !ok {
+					return nil, fmt.Errorf("trino: %s must be a string, got %T", accessTokenConfig, arg.Value)
+				}
 				hs.Add(authorizationHeader, getAuthorization(token))
 				continue
 			}

--- a/trino/trino_test.go
+++ b/trino/trino_test.go
@@ -21,6 +21,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"io"
 	"math"
 	"net/http"
 	"net/http/httptest"
@@ -3686,6 +3687,43 @@ func TestForwardAuthorizationHeader(t *testing.T) {
 	require.Equal(t, "Bearer token", captureAuthHeader, "Authorization header is incorrect")
 
 	assert.NoError(t, db.Close())
+}
+
+func TestForwardAuthorizationHeaderDisabled(t *testing.T) {
+	var capturedQuery string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		capturedQuery = string(body)
+	}))
+
+	t.Cleanup(ts.Close)
+
+	db, err := sql.Open("trino", ts.URL)
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		assert.NoError(t, db.Close())
+	})
+
+	_, err = db.Query("SELECT ?", sql.Named("accessToken", "token"))
+	assert.ErrorIs(t, err, ErrForwardAuthorizationHeaderNotEnabled)
+	assert.NotContains(t, capturedQuery, "token", "the access token must never reach the query text")
+}
+
+func TestForwardAuthorizationHeaderNonStringToken(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	t.Cleanup(ts.Close)
+
+	db, err := sql.Open("trino", ts.URL+"?forwardAuthorizationHeader=true")
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		assert.NoError(t, db.Close())
+	})
+
+	_, err = db.Query("SELECT ?", sql.Named("accessToken", 42))
+	assert.EqualError(t, err, "trino: accessToken must be a string, got int64")
 }
 
 func TestQueryTimeoutDeadline(t *testing.T) {


### PR DESCRIPTION
Fixes #204

The `accessToken` named argument was only recognized when `ForwardAuthorizationHeader` was set. Without it, the token fell through to the normal parameter path and was inlined into the query text (`EXECUTE _trino_go USING '<token>'`), where Trino persists it in the query history, event listeners and Web UI — silently, with no error.

`accessToken` is now always recognized, and returns an error when forwarding is not enabled, so the token can never reach the query text. Also replaced the unchecked type assertion on the token value, which panicked on a non-string.

Note: this is a behavior change for anyone binding a query parameter literally named `accessToken`.